### PR TITLE
Add GUI entry point and prepare for PyInstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
   <img src="ANYtimes_logo.png" alt="AnytimeSeries logo" width="200"/>
 </p>
 
-# AnytimeSeries Qt
+# AnytimeSeries
 
-AnytimeSeries Qt provides a PySide6-based interface for exploring and editing time-series data. The application integrates with the [qats](https://pypi.org/project/qats/) package and supports various file formats for loading and visualising time-series information.
+AnytimeSeries provides a PySide6-based interface for exploring and editing time-series data. The application integrates with the [qats](https://pypi.org/project/qats/) package and supports various file formats for loading and visualising time-series information.
 
 ## Installation
 
@@ -23,13 +23,13 @@ pip install anytimes
 
 ## Usage
 
-After installation, import the module in your Python project:
+After installation, import the GUI module in your Python project:
 
 ```python
-from anytimes import qt
+from anytimes import anytimes_gui
 ```
 
-The module exposes Qt widgets for building custom time-series exploration tools.
+The module exposes Qt widgets for building custom time-series exploration tools. You can also launch the GUI from the command line using the `anytimes` entry point.
 
 ## License
 

--- a/anytimes/__init__.py
+++ b/anytimes/__init__.py
@@ -1,3 +1,4 @@
-from .qt import *
+from . import anytimes_gui
+from .anytimes_gui import *
 
 __all__ = [name for name in globals() if not name.startswith('_')]

--- a/anytimes/__main__.py
+++ b/anytimes/__main__.py
@@ -1,0 +1,4 @@
+from .anytimes_gui import main
+
+if __name__ == "__main__":
+    main()

--- a/anytimes/anytimes_gui.py
+++ b/anytimes/anytimes_gui.py
@@ -1,4 +1,4 @@
-# ANYtimeseries PySide6 with universal FileLoader
+# AnytimeSeries PySide6 with universal FileLoader
 import sys
 import os
 
@@ -254,7 +254,7 @@ class VariableRowWidget(QWidget):
 class TimeSeriesEditorQt(QMainWindow):
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("ANYtimes - time series editor (Qt/PySide6)")
+        self.setWindowTitle("AnytimeSeries - time series editor (Qt/PySide6)")
 
 
 
@@ -5827,9 +5827,14 @@ def get_object_available_vars(obj, orcaflex_varmap=None):
 
 
 
-if __name__ == "__main__":
+def main():
+    """Launch the AnytimeSeries GUI."""
     app = QApplication(sys.argv)
     window = TimeSeriesEditorQt()
     window.resize(1400, 800)
     window.show()
     sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,11 @@ dependencies = [
     "scipy",
     "qats",
     "PySide6",
-    "matplotlib"
+    "matplotlib",
 ]
+
+[project.scripts]
+anytimes = "anytimes.anytimes_gui:main"
 
 [project.urls]
 Homepage = "https://github.com/example/anytimes"


### PR DESCRIPTION
## Summary
- rename `qt` module to `anytimes_gui` and export it from the package
- add `main()` launcher and `__main__` module for PyInstaller
- expose `anytimes` console script for easier launching
- update README with new import path, entry point usage, and AnytimeSeries branding

## Testing
- `python -m py_compile anytimes/__init__.py anytimes/__main__.py anytimes/anytimes_gui.py`
- `python - <<'PY'
import anytimes
print('anytimes_gui' in dir(anytimes))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a824ad4b60832c83068b656af09148