### PR TITLE
Replace qats dependency with bundled anyqats

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # AnytimeSeries
 
-AnytimeSeries provides a PySide6-based interface for exploring and editing time-series data. The application integrates with the [qats](https://pypi.org/project/qats/) package and supports various file formats for loading and visualising time-series information.
+AnytimeSeries provides a PySide6-based interface for exploring and editing time-series data. The application integrates with the bundled anyqats package and supports various file formats for loading and visualising time-series information.
 
 ## Installation
 
@@ -17,7 +17,7 @@ pip install anytimes
 - numpy
 - pandas
 - scipy
-- qats
+- anyqats
 - PySide6
 - matplotlib
 

--- a/anyqats/__init__.py
+++ b/anyqats/__init__.py
@@ -2,8 +2,8 @@
 """
 Library for efficient processing and visualization of time series.
 """
-from qats.ts import TimeSeries
-from qats.tsdb import TsDB
+from .ts import TimeSeries
+from .tsdb import TsDB
 
 # version
 try:

--- a/anyqats/__main__.py
+++ b/anyqats/__main__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from qats import cli
+from . import cli
 
 if __name__ == '__main__':
     cli.main()

--- a/anyqats/app/__init__.py
+++ b/anyqats/app/__init__.py
@@ -1,9 +1,9 @@
-"""Support for launching the QATS GUI.
+"""Support for launching the AnyQATS GUI.
 
 This module exposes a :func:`main` function that serves as an entry point
-for the desktop application.  It delegates to :func:`qats.cli.launch_app`
+for the desktop application.  It delegates to :func:`anyqats.cli.launch_app`
 with default arguments, allowing the GUI to be started simply by executing
-``python -m qats.app``.
+``python -m anyqats.app``.
 """
 
 from __future__ import annotations
@@ -13,13 +13,13 @@ def main() -> None:
     """Launch the graphical user interface.
 
     The heavy lifting of setting up and starting the application lives in
-    :func:`qats.cli.launch_app`.  Importing inside the function keeps import
+    :func:`anyqats.cli.launch_app`.  Importing inside the function keeps import
     time light and avoids circular dependencies during package initialisation.
     """
 
     from ..cli import launch_app
 
-    # Mirror the default behaviour of ``qats app`` which uses the current
+    # Mirror the default behaviour of ``anyqats app`` which uses the current
     # working directory unless the user specifies otherwise.
     launch_app(home=False)
 

--- a/anyqats/app/__main__.py
+++ b/anyqats/app/__main__.py
@@ -1,6 +1,6 @@
-"""Module entry point for :mod:`qats.app`.
+"""Module entry point for :mod:`anyqats.app`.
 
-Executing ``python -m qats.app`` will invoke :func:`qats.app.main` and
+Executing ``python -m anyqats.app`` will invoke :func:`anyqats.app.main` and
 start the graphical user interface.
 """
 

--- a/anyqats/app/gui.py
+++ b/anyqats/app/gui.py
@@ -66,15 +66,15 @@ LOGGING_LEVELS = dict(
 )
 # define path to settings file
 if sys.platform == "win32":
-    SETTINGS_FILE = os.path.join(os.getenv("APPDATA", os.getenv("USERPROFILE", "")), "qats.settings")
+    SETTINGS_FILE = os.path.join(os.getenv("APPDATA", os.getenv("USERPROFILE", "")), "anyqats.settings")
 else:
-    SETTINGS_FILE = os.path.join("~", ".config", "qats.settings")
+    SETTINGS_FILE = os.path.join("~", ".config", "anyqats.settings")
 
 # create icon file handle
 # ref. https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename
 icofile_manager = contextlib.ExitStack()
 atexit.register(icofile_manager.close)
-icoref = resources.files("qats.app") / "qats.ico"
+icoref = resources.files("anyqats.app") / "qats.ico"
 ICON_PATH = icofile_manager.enter_context(resources.as_file(icoref))
 ICON_FILE = str(ICON_PATH.absolute())
 
@@ -122,14 +122,14 @@ STATS_LABELS_TOOLTIPS = {
 
 class Qats(QMainWindow):
     """
-    Main window for the QATS application.
+    Main window for the AnyQATS application.
 
     Contain widgets for plotting time series, power spectra and statistics.
 
     Series of data are loaded from a time series file (e.g., .ts), and their names are displayed in a checkable 
     list view. The user can select the series it wants from the list and plot them on a matplotlib canvas. The 
-    base library is used to load time series from file (`qats.io`), perform signal processing (`qats.signal`), 
-    calculating power spectra and statistics (`qats.stats`) and plotting.
+    base library is used to load time series from file (`anyqats.io`), perform signal processing (`anyqats.signal`),
+    calculating power spectra and statistics (`anyqats.stats`) and plotting.
     """
 
     def __init__(self, parent=None, files_on_init=None, logging_level="info"):
@@ -707,7 +707,7 @@ class Qats(QMainWindow):
         """
         msg = "This is a low threshold tool for inspection of time series, power spectra and statistics. " \
               "Its main objective is to ease self-check, quality assurance and reporting.<br><br>" \
-              "Import qats Python package and use the <a href='https://qats.readthedocs.io/en/latest/'>API</a> " \
+              "Import anyqats Python package and use the <a href='https://qats.readthedocs.io/en/latest/'>API</a> " \
               "when you need advanced features or want to extend it's functionality.<br><br>" \
               "Please send feature requests, technical queries and bug reports to the developers on " \
               "<a href='https://github.com/dnvgl/qats/issues'>Github</a>.<br><br>" \

--- a/anyqats/cli.py
+++ b/anyqats/cli.py
@@ -16,8 +16,8 @@ from .app.gui import LOGGING_LEVELS, Qats
 
 def link_app():
     """
-    Create start menu item and desktop shortcut to `qats` desktop app
-    (by invoking pythonw.exe with the necessary arguments, not the 
+    Create start menu item and desktop shortcut to `anyqats` desktop app
+    (by invoking pythonw.exe with the necessary arguments, not the
     previous entry point qats-app.exe (or .cmd)).
     """
     if not sys.platform == "win32":
@@ -26,8 +26,8 @@ def link_app():
 
     from win32com.client import Dispatch
 
-    pkg_name = "qats"
-    ico_ref = resources.files("qats.app") / "qats.ico"
+    pkg_name = "anyqats"
+    ico_ref = resources.files("anyqats.app") / "qats.ico"
     lnk_name = pkg_name.upper() + ".lnk"
 
     # define target as pythonw.exe (or python.exe if needed)
@@ -40,7 +40,7 @@ def link_app():
         target = python_exec_path
 
     # define arguments to target
-    # (relies on invoking qats.__main__, not the entry point executable)
+    # (relies on invoking anyqats.__main__, not the entry point executable)
     arguments = f"-m {pkg_name} app"
     
     # open shell
@@ -62,7 +62,7 @@ def link_app():
 
 def unlink_app():
     """
-    Remove start menu item and desktop shortcut to `qats` desktop application.
+    Remove start menu item and desktop shortcut to `anyqats` desktop application.
     """
     if not sys.platform == "win32":
         print(f"Unable to remove links to app on {sys.platform} OS.")
@@ -70,7 +70,7 @@ def unlink_app():
 
     from win32com.client import Dispatch
 
-    pkg_name = "qats"
+    pkg_name = "anyqats"
     lnk_name = pkg_name.upper() + ".lnk"
 
     shell = Dispatch("WScript.Shell")
@@ -113,9 +113,9 @@ def main():
     Launch desktop application from command line with parameters.
     """
     # top-level parser
-    parser = argparse.ArgumentParser(prog="qats",
-                                     description="qats is a library and desktop application for time series analysis")
-    parser.add_argument("--version", action="version", version=f"qats {__version__}", help="Package version")
+    parser = argparse.ArgumentParser(prog="anyqats",
+                                     description="anyqats is a library and desktop application for time series analysis")
+    parser.add_argument("--version", action="version", version=f"anyqats {__version__}", help="Package version")
     subparsers = parser.add_subparsers(title="Commands", dest="command")
 
     # app parser

--- a/anytimes/anytimes_gui.py
+++ b/anytimes/anytimes_gui.py
@@ -15,8 +15,8 @@ import pandas as pd
 import scipy.io
 import json
 import subprocess
-import qats
-from qats import TimeSeries, TsDB
+import anyqats as qats
+from anyqats import TimeSeries, TsDB
 from PySide6.QtWidgets import (
     QMainWindow, QWidget, QHBoxLayout, QVBoxLayout, QGridLayout,
     QListWidget, QTabWidget, QLabel, QLineEdit, QCheckBox, QRadioButton,
@@ -45,7 +45,7 @@ Supports generic (csv, mat, h5, etc) and OrcaFlex .sim files with Qt-based varia
 
 
 # You should provide these in your app context:
-# from qats import TsDB, TimeSeries
+# from anyqats import TsDB, TimeSeries
 # import OrcFxAPI (for .sim files)
 class SortableTableWidgetItem(QTableWidgetItem):
     def __lt__(self, other):
@@ -271,7 +271,7 @@ class TimeSeriesEditorQt(QMainWindow):
         # =======================
         # DATA STRUCTURES
         # =======================
-        self.tsdbs = []                # List of qats.TsDB instances (one per file)
+        self.tsdbs = []                # List of anyqats.TsDB instances (one per file)
         self.file_paths = []           # List of file paths (order matches tsdbs)
         self.user_variables = set()    # User-defined/calculated variables
 
@@ -531,7 +531,7 @@ class TimeSeriesEditorQt(QMainWindow):
         # ---- Tools (EVA + QATS) ----
         self.tools_group = QGroupBox("Tools")
         tools_layout = QHBoxLayout(self.tools_group)
-        self.launch_qats_btn = QPushButton("Open in QATS")
+        self.launch_qats_btn = QPushButton("Open in AnyQATS")
         self.evm_tool_btn = QPushButton("Open Extreme Value Statistics Tool")
         tools_layout.addWidget(self.launch_qats_btn)
         tools_layout.addWidget(self.evm_tool_btn)
@@ -1324,7 +1324,7 @@ class TimeSeriesEditorQt(QMainWindow):
         """
         import os
         from PySide6.QtCore import QTimer
-        from qats import TimeSeries
+        from anyqats import TimeSeries
 
         self.rebuild_var_lookup()
         made = []
@@ -1450,7 +1450,7 @@ class TimeSeriesEditorQt(QMainWindow):
           gets exactly one result (the filename part is already unique).
         """
         import numpy as np, os, re
-        from qats import TimeSeries
+        from anyqats import TimeSeries
         from PySide6.QtCore import QTimer
         from PySide6.QtWidgets import QMessageBox
 
@@ -1594,7 +1594,7 @@ class TimeSeriesEditorQt(QMainWindow):
           distinguishes them, so no extra suffix is added.)
         """
         import numpy as np, os, re
-        from qats import TimeSeries
+        from anyqats import TimeSeries
         from PySide6.QtWidgets import QMessageBox
 
         sel_keys = [k for k, ck in self.var_checkboxes.items() if ck.isChecked()]
@@ -2400,10 +2400,10 @@ class TimeSeriesEditorQt(QMainWindow):
 
         self.rebuild_var_lookup()
 
-        import numpy as np, qats, os
+        import numpy as np, anyqats as qats, os
         from PySide6.QtWidgets import QMessageBox
         import matplotlib.pyplot as plt
-        from qats import TimeSeries
+        from anyqats import TimeSeries
 
         roll_window = 1
         if hasattr(self, "rolling_window"):
@@ -2651,7 +2651,7 @@ class TimeSeriesEditorQt(QMainWindow):
             start, stop = stop, start
 
         try:
-            import qats, numpy as _np
+            import anyqats as qats, numpy as _np
 
             try:
                 # Preferred when available
@@ -2700,7 +2700,7 @@ class TimeSeriesEditorQt(QMainWindow):
         import pandas as pd
         import plotly.express as px
         from PySide6.QtWidgets import QMessageBox as mb
-        from qats import TimeSeries
+        from anyqats import TimeSeries
 
         # ──────────────────────────────────────────────────────────────────
         # helper: filter + resample ONE series and return a *new* TimeSeries
@@ -3381,7 +3381,7 @@ class TimeSeriesEditorQt(QMainWindow):
 
     def launch_qats(self):
         if not getattr(self, "work_dir", None):
-            self.work_dir = QFileDialog.getExistingDirectory(self, "Select Work Folder for QATS Export")
+            self.work_dir = QFileDialog.getExistingDirectory(self, "Select Work Folder for AnyQATS Export")
             if not self.work_dir:
                 return
         ts_paths = []
@@ -3391,9 +3391,9 @@ class TimeSeriesEditorQt(QMainWindow):
             tsdb.export(ts_path, names=list(tsdb.getm().keys()), force_common_time=True)
             ts_paths.append(ts_path)
         try:
-            subprocess.Popen([sys.executable, "-m", "qats", "app", "-f"] + ts_paths)
+            subprocess.Popen([sys.executable, "-m", "anyqats", "app", "-f"] + ts_paths)
         except FileNotFoundError:
-            QMessageBox.critical(self, "Error", "QATS could not be launched using the current Python environment.")
+            QMessageBox.critical(self, "Error", "AnyQATS could not be launched using the current Python environment.")
 
     def open_evm_tool(self):
         """Launch the Extreme Value Analysis tool for the first checked variable."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "numpy",
     "pandas",
     "scipy",
-    "qats",
     "PySide6",
     "matplotlib",
 ]
@@ -27,4 +26,4 @@ Homepage = "https://github.com/example/anytimes"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["anytimes*"]
+include = ["anytimes*", "anyqats*"]


### PR DESCRIPTION
## Summary
- use the bundled `anyqats` package instead of the external `qats`
- adjust GUI and CLI code to reference `anyqats`
- remove `qats` from project dependencies

## Testing
- `python -m pytest`
- `python -m py_compile anytimes/anytimes_gui.py anyqats/__init__.py anyqats/__main__.py anyqats/cli.py anyqats/app/gui.py anyqats/app/__init__.py anyqats/app/__main__.py`

------
https://chatgpt.com/codex/tasks/task_e_68a85498992c832ca216194478a8935f