### PR TITLE
Handle list-like columns from feather files

### DIFF
--- a/anytimes/anytimes_gui.py
+++ b/anytimes/anytimes_gui.py
@@ -17,6 +17,8 @@ import json
 import subprocess
 import anyqats as qats
 from anyqats import TimeSeries, TsDB
+from collections.abc import Sequence
+from array import array
 from PySide6.QtWidgets import (
     QMainWindow, QWidget, QHBoxLayout, QVBoxLayout, QGridLayout,
     QListWidget, QTabWidget, QLabel, QLineEdit, QCheckBox, QRadioButton,
@@ -6139,7 +6141,7 @@ class FileLoader:
             c
             for c in df.columns
             if c != time_col
-            and df[c].dtype == object
+            and pd.api.types.is_string_dtype(df[c])
             and df[c].map(lambda x: isinstance(x, str) or pd.isna(x)).all()
         ]
         for sc in string_cols:
@@ -6162,9 +6164,27 @@ class FileLoader:
                 for col in df.columns:
                     if col in (time_col, id_col):
                         continue
-                    values = subdf[col].values
-                    if all(isinstance(v, (list, tuple, np.ndarray)) for v in values):
-                        lengths = {len(v) for v in values}
+                    # ensure any pyarrow/extension values are converted to
+                    # regular Python objects before further inspection
+                    values = []
+                    for v in subdf[col].tolist():
+                        if hasattr(v, "to_pylist"):
+                            v = v.to_pylist()
+                        elif isinstance(v, array):
+                            v = list(v)
+                        values.append(v)
+                    # consider only non-null entries when checking for list-like values
+                    non_null = []
+                    for v in values:
+                        if isinstance(v, Sequence) and not isinstance(v, (str, bytes)):
+                            non_null.append(v)
+                        elif not pd.isna(v):
+                            non_null.append(v)
+                    if non_null and all(
+                        isinstance(v, Sequence) and not isinstance(v, (str, bytes))
+                        for v in non_null
+                    ):
+                        lengths = {len(v) for v in non_null}
                         if len(lengths) == 1:
                             n = lengths.pop()
                             resp = QMessageBox.question(
@@ -6187,30 +6207,52 @@ class FileLoader:
                                 if len(names) != n:
                                     names = [f"{col}_{i+1}" for i in range(n)]
                                 for i in range(n):
-
+                                    row_vals = []
+                                    for row in values:
+                                        if isinstance(row, Sequence) and not isinstance(row, (str, bytes)):
+                                            try:
+                                                row_vals.append(row[i])
+                                            except Exception:
+                                                row_vals.append(np.nan)
+                                        else:
+                                            row_vals.append(np.nan)
                                     try:
-                                        data = np.array(
-                                            [np.asarray(row[i]).item() for row in values],
-                                            dtype=float,
-                                        )
+                                        data = np.array(row_vals, dtype=float)
                                     except Exception:
                                         skipped.add(f"{col}_{i}")
                                         continue
 
                                     tsdb.add(TimeSeries(f"{names[i]}_{ident}", time_vals, data))
                                 continue
-                    if np.issubdtype(values.dtype, np.number) and np.isfinite(values).all():
-                        tsdb.add(TimeSeries(f"{col}_{ident}", time_vals, values))
-                    else:
+                    try:
+                        numeric_values = np.array(values, dtype=float)
+                        tsdb.add(TimeSeries(f"{col}_{ident}", time_vals, numeric_values))
+                    except Exception:
                         skipped.add(col)
         else:
             for col in df.columns:
                 if col == time_col:
                     continue
-                values = df[col].values
-                # Check for columns with list/tuple values of consistent length
-                if all(isinstance(v, (list, tuple, np.ndarray)) for v in values):
-                    lengths = {len(v) for v in values}
+                # Convert potential extension array values to regular Python
+                values = []
+                for v in df[col].tolist():
+                    if hasattr(v, "to_pylist"):
+                        v = v.to_pylist()
+                    elif isinstance(v, array):
+                        v = list(v)
+                    values.append(v)
+                # Consider only non-null entries when checking for list-like values
+                non_null = []
+                for v in values:
+                    if isinstance(v, Sequence) and not isinstance(v, (str, bytes)):
+                        non_null.append(v)
+                    elif not pd.isna(v):
+                        non_null.append(v)
+                if non_null and all(
+                    isinstance(v, Sequence) and not isinstance(v, (str, bytes))
+                    for v in non_null
+                ):
+                    lengths = {len(v) for v in non_null}
                     if len(lengths) == 1:
                         n = lengths.pop()
                         resp = QMessageBox.question(
@@ -6233,21 +6275,27 @@ class FileLoader:
                             if len(names) != n:
                                 names = [f"{col}_{i+1}" for i in range(n)]
                             for i in range(n):
-
+                                row_vals = []
+                                for row in values:
+                                    if isinstance(row, Sequence) and not isinstance(row, (str, bytes)):
+                                        try:
+                                            row_vals.append(row[i])
+                                        except Exception:
+                                            row_vals.append(np.nan)
+                                    else:
+                                        row_vals.append(np.nan)
                                 try:
-                                    data = np.array(
-                                        [np.asarray(row[i]).item() for row in values],
-                                        dtype=float,
-                                    )
+                                    data = np.array(row_vals, dtype=float)
                                 except Exception:
                                     skipped.add(f"{col}_{i}")
                                     continue
 
                                 tsdb.add(TimeSeries(names[i], time, data))
                             continue
-                if np.issubdtype(values.dtype, np.number) and np.isfinite(values).all():
-                    tsdb.add(TimeSeries(col, time, values))
-                else:
+                try:
+                    numeric_values = np.array(values, dtype=float)
+                    tsdb.add(TimeSeries(col, time, numeric_values))
+                except Exception:
                     skipped.add(col)
         if len(tsdb.getm()) == 0:
             if 'time' in df.columns or 't' in df.columns:


### PR DESCRIPTION
## Summary
- widen identifier-column detection to pandas string dtypes
- treat any Sequence values (including array.array) as list-like and split safely
- guard list-like column splitting against null entries when grouping by an identifier
- skip pd.isna on sequence values to avoid ambiguous truth-value errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aededa96e0832cb33779634504365f