### PR TITLE
Handle numpy arrays when splitting generic file columns

### DIFF
--- a/anytimes/anytimes_gui.py
+++ b/anytimes/anytimes_gui.py
@@ -6176,6 +6176,8 @@ class FileLoader:
                             v = v.to_pylist()
                         elif isinstance(v, array):
                             v = list(v)
+                        elif isinstance(v, np.ndarray):
+                            v = v.tolist()
                         values.append(v)
                     # consider only non-null entries when checking for list-like values
                     non_null = []
@@ -6244,6 +6246,8 @@ class FileLoader:
                         v = v.to_pylist()
                     elif isinstance(v, array):
                         v = list(v)
+                    elif isinstance(v, np.ndarray):
+                        v = v.tolist()
                     values.append(v)
                 # Consider only non-null entries when checking for list-like values
                 non_null = []


### PR DESCRIPTION
## Summary
- fix ambiguous truth-value error by converting NumPy arrays to lists when loading generic files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeeca89484832c85e932cb3c255fb8