### PR TITLE
Add select-all Sims button in OrcaFlex picker

### DIFF
--- a/anytimes/anytimes_gui.py
+++ b/anytimes/anytimes_gui.py
@@ -5588,7 +5588,15 @@ class FileLoader:
         file_group = QGroupBox("Select Sims for this selection")
         file_layout = QVBoxLayout(file_group)
         file_checks = {}
+        select_all_btn = QPushButton("Select All Sims")
+        file_layout.addWidget(select_all_btn)
         status_label = QLabel()
+
+        def select_all_sims():
+            for cb in file_checks.values():
+                cb.setChecked(True)
+
+        select_all_btn.clicked.connect(select_all_sims)
 
         def check_files(*_):
             selected = [fp for fp, cb in file_checks.items() if cb.isChecked()]


### PR DESCRIPTION
## Summary
- add "Select All Sims" button to OrcaFlex variable selection dialog so users can quickly tick all loaded .sim files

## Testing
- `python -m py_compile anytimes/anytimes_gui.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b49a22f764832caedded736a120bdd