### PR TITLE
Fix AnyQATS launch to include exported time series

### DIFF
--- a/anytimes/anytimes_gui.py
+++ b/anytimes/anytimes_gui.py
@@ -3744,7 +3744,8 @@ class TimeSeriesEditorQt(QMainWindow):
             tsdb.export(ts_path, names=list(tsdb.getm().keys()), force_common_time=True)
             ts_paths.append(ts_path)
         try:
-            subprocess.Popen([sys.executable, "-m", "anyqats", "app", "-f"] + ts_paths)
+            cmd = [sys.executable, "-m", "anyqats.cli", "app", "-f"] + ts_paths
+            subprocess.Popen(cmd)
         except FileNotFoundError:
             QMessageBox.critical(self, "Error", "AnyQATS could not be launched using the current Python environment.")
 


### PR DESCRIPTION
## Summary
- Ensure AnyQATS CLI receives exported series paths when launching from AnyTimes
- Build command with `anyqats.cli` to allow argument parsing

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b58d87681c832c8d2c58239f2aa766