### PR TITLE
Fix duplicate merged series across files

### DIFF
--- a/anytimes/gui/editor.py
+++ b/anytimes/gui/editor.py
@@ -1429,9 +1429,12 @@ class TimeSeriesEditorQt(QMainWindow):
 
                 merged_ts = TimeSeries(name, merged_t, merged_x)
                 if self.tsdbs:
+                    # The merged result should behave like a single user variable.
+                    # Adding duplicates to every file leads to repeated plots and
+                    # duplicated entries.  Keep a single authoritative copy in the
+                    # first database so downstream features (plotting, stats, …)
+                    # only see one series.
                     self.tsdbs[0].add(merged_ts)
-                    for tsdb in self.tsdbs[1:]:
-                        tsdb.add(TimeSeries(name, merged_t.copy(), merged_x.copy()))
                 self.user_variables.add(name)
                 created.append(name)
         else:

--- a/tests/test_merge_selected.py
+++ b/tests/test_merge_selected.py
@@ -118,11 +118,16 @@ def test_merge_common_single_series_creates_user_variables(qt_app, message_spy, 
     editor.merge_selected_series()
     qt_app.processEvents()
 
-    expected = {"merge(CommonVar)_f1", "merge(CommonVar)_f2", "merge(CommonVar)_f3"}
+    expected = "merge(CommonVar)"
     created = set()
     for tsdb in editor.tsdbs:
         created.update(name for name in tsdb.getm() if name.startswith("merge(CommonVar)"))
-    assert expected <= created
+
+    assert created == {expected}
+    # Only the first database should receive the merged copy.
+    assert expected in editor.tsdbs[0].getm()
+    for tsdb in editor.tsdbs[1:]:
+        assert expected not in tsdb.getm()
     assert not message_spy["crit"]
     assert not message_spy["warn"]
 
@@ -141,10 +146,14 @@ def test_merge_common_name_with_colon_not_misclassified(qt_app, message_spy, mon
     editor.merge_selected_series()
     qt_app.processEvents()
 
-    expected = {"merge(Var)_f1", "merge(Var)_f2", "merge(Var)_f3"}
+    expected = "merge(Var)"
     created = set()
     for tsdb in editor.tsdbs:
         created.update(name for name in tsdb.getm() if name.startswith("merge(Var)"))
-    assert expected <= created
+
+    assert created == {expected}
+    assert expected in editor.tsdbs[0].getm()
+    for tsdb in editor.tsdbs[1:]:
+        assert expected not in tsdb.getm()
     assert not message_spy["crit"]
     assert not message_spy["warn"]


### PR DESCRIPTION
## Summary
- stop `merge selected` from cloning the new user series into every open file, leaving a single authoritative copy instead
- update the merge tests to assert that only one merged variable is created and that it lives in the primary database

## Testing
- `pytest tests/test_merge_selected.py::test_merge_common_single_series_creates_user_variables -q` *(fails: missing libGL.so.1 in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbbba2b2ec832cb86fc0091dd615a4