### PR TITLE
Add deterministic tests for extreme value analysis

### DIFF
--- a/anytimes/__init__.py
+++ b/anytimes/__init__.py
@@ -1,4 +1,11 @@
-from . import anytimes_gui
-from .anytimes_gui import *
+"""ANYtimes public package interface."""
+
+try:
+    from . import anytimes_gui  # noqa: F401
+    from .anytimes_gui import *  # noqa: F401,F403
+except Exception:  # pragma: no cover - GUI dependencies are optional during tests
+    anytimes_gui = None  # type: ignore[assignment]
+
+from . import evm  # noqa: F401
 
 __all__ = [name for name in globals() if not name.startswith('_')]

--- a/anytimes/evm.py
+++ b/anytimes/evm.py
@@ -1,0 +1,146 @@
+"""Utility functions for Extreme Value (Generalized Pareto) analysis."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+from scipy.stats import genpareto
+
+
+@dataclass(frozen=True)
+class ExtremeValueResult:
+    """Container for Generalized Pareto extreme value analysis results."""
+
+    return_periods: np.ndarray
+    return_levels: np.ndarray
+    lower_bounds: np.ndarray
+    upper_bounds: np.ndarray
+    shape: float
+    scale: float
+    exceedances: np.ndarray
+    threshold: float
+    exceedance_rate: float
+
+
+def cluster_exceedances(x: np.ndarray, threshold: float, tail: str) -> np.ndarray:
+    """Return the cluster peaks that exceed *threshold*.
+
+    The GUI performs a crude declustering by splitting the signal on mean level
+    crossings and picking the most extreme value in each segment. Re-use the
+    same logic here so that the behaviour can be tested without the GUI.
+    """
+
+    if tail not in {"upper", "lower"}:
+        raise ValueError("tail must be 'upper' or 'lower'")
+
+    mean_val = np.mean(x)
+    cross_type = np.greater if tail == "upper" else np.less
+    cross_indices = np.where(np.diff(cross_type(x, mean_val)))[0]
+    if cross_indices.size == 0 or cross_indices[-1] != len(x) - 1:
+        cross_indices = np.append(cross_indices, len(x) - 1)
+
+    clustered_peaks: list[float] = []
+    for i in range(len(cross_indices) - 1):
+        segment = x[cross_indices[i] : cross_indices[i + 1]]
+        peak = np.max(segment) if tail == "upper" else np.min(segment)
+        if (tail == "upper" and peak > threshold) or (
+            tail == "lower" and peak < threshold
+        ):
+            clustered_peaks.append(peak)
+
+    return np.asarray(clustered_peaks, dtype=float)
+
+
+def calculate_extreme_value_statistics(
+    t: np.ndarray,
+    x: np.ndarray,
+    threshold: float,
+    *,
+    tail: str = "upper",
+    return_periods_hours: Sequence[float] = (0.1, 0.5, 1, 3, 5),
+    confidence_level: float = 95.0,
+    n_bootstrap: int = 500,
+    rng: np.random.Generator | None = None,
+    clustered_peaks: np.ndarray | None = None,
+) -> ExtremeValueResult:
+    """Estimate return levels using the Generalized Pareto distribution.
+
+    Parameters
+    ----------
+    t, x:
+        Time stamps and samples of the signal.
+    threshold:
+        Level above which exceedances are analysed.
+    tail:
+        "upper" for high extremes, "lower" for low extremes.
+    return_periods_hours:
+        Iterable of return periods (in hours) for which to compute levels.
+    confidence_level:
+        Percent confidence level for the bootstrap interval.
+    n_bootstrap:
+        Number of bootstrap iterations.
+    rng:
+        Optional :class:`numpy.random.Generator` for deterministic bootstrapping.
+    """
+
+    if tail not in {"upper", "lower"}:
+        raise ValueError("tail must be 'upper' or 'lower'")
+
+    if clustered_peaks is None:
+        clustered_peaks = cluster_exceedances(x, threshold, tail)
+    else:
+        clustered_peaks = np.asarray(clustered_peaks, dtype=float)
+    if clustered_peaks.size == 0:
+        raise ValueError("No exceedances found above the provided threshold")
+
+    excesses = clustered_peaks - threshold
+    c, loc, scale = genpareto.fit(excesses, floc=0)
+
+    exceed_prob = clustered_peaks.size / (t[-1] - t[0])
+    return_periods = np.asarray(tuple(return_periods_hours), dtype=float)
+    return_secs = return_periods * 3600
+    return_levels = threshold + (scale / c) * ((exceed_prob * return_secs) ** c - 1)
+
+    rng = np.random.default_rng() if rng is None else rng
+    boot_levels: list[np.ndarray] = []
+    for _ in range(n_bootstrap):
+        sample = rng.choice(excesses, size=excesses.size, replace=True)
+        try:
+            bc, _, bscale = genpareto.fit(sample, floc=0)
+        except Exception:
+            continue
+        boot_level = threshold + (bscale / bc) * ((exceed_prob * return_secs) ** bc - 1)
+        if np.isnan(boot_level).any():
+            continue
+        if not ((boot_level > -1e6).all() and (boot_level < 1e6).all()):
+            continue
+        boot_levels.append(boot_level)
+
+    if boot_levels:
+        boot_arr = np.vstack(boot_levels)
+        ci_alpha = 100 - confidence_level
+        lower_bounds = np.percentile(boot_arr, ci_alpha / 2, axis=0)
+        upper_bounds = np.percentile(boot_arr, 100 - ci_alpha / 2, axis=0)
+    else:
+        lower_bounds = upper_bounds = np.full(return_levels.shape, np.nan)
+
+    return ExtremeValueResult(
+        return_periods=return_periods,
+        return_levels=return_levels,
+        lower_bounds=lower_bounds,
+        upper_bounds=upper_bounds,
+        shape=float(c),
+        scale=float(scale),
+        exceedances=clustered_peaks,
+        threshold=float(threshold),
+        exceedance_rate=float(exceed_prob),
+    )
+
+
+__all__ = [
+    "ExtremeValueResult",
+    "calculate_extreme_value_statistics",
+    "cluster_exceedances",
+]
+

--- a/anytimes/gui/evm_window.py
+++ b/anytimes/gui/evm_window.py
@@ -17,6 +17,8 @@ from PySide6.QtWidgets import (
     QMessageBox,
 )
 
+from anytimes.evm import calculate_extreme_value_statistics
+
 class EVMWindow(QDialog):
     def __init__(self, tsdb, var_name, parent=None):
         super().__init__(parent)
@@ -129,7 +131,9 @@ class EVMWindow(QDialog):
                 tail == "lower" and peak < threshold
             ):
                 clustered_peaks.append(peak)
-        return clustered_peaks, cross_indices
+        # use numpy array like helper does to ensure consistent type
+        clustered_peaks_arr = np.array(clustered_peaks, dtype=float)
+        return clustered_peaks_arr, cross_indices
 
     def on_manual_threshold(self):
         self.threshold_spin.interpretText()
@@ -178,9 +182,6 @@ class EVMWindow(QDialog):
         layout.addWidget(run_btn, 4, 0, 1, 3)
 
     def run_evm(self):
-
-        from scipy.stats import genpareto
-
         x = self.x
         t = self.t
 
@@ -198,8 +199,17 @@ class EVMWindow(QDialog):
             )
             return
 
-        excesses = np.array(clustered_peaks) - threshold
-        c, loc, scale = genpareto.fit(excesses, floc=0)
+        evm_result = calculate_extreme_value_statistics(
+            t,
+            x,
+            threshold,
+            tail=tail,
+            confidence_level=self.ci_spin.value(),
+            clustered_peaks=clustered_peaks,
+        )
+
+        c = evm_result.shape
+        scale = evm_result.scale
 
         # Diagnostic: warn if shape is too extreme
         if abs(c) > 1:
@@ -209,64 +219,42 @@ class EVMWindow(QDialog):
         if c < -1e-6:
             print("Note: fitted GPD shape xi < 0 indicates a bounded tail.")
 
-        exceed_prob = len(clustered_peaks) / (t[-1] - t[0])
-
-        return_periods = np.array([0.1, 0.5, 1, 3, 5])  # hours
-        return_secs = return_periods * 3600
-        rl = threshold + (scale / c) * ((exceed_prob * return_secs) ** c - 1)
-
-        n_bootstrap = 500
-        boot_levels = []
-        rs = np.random.default_rng()
-
-        for _ in range(n_bootstrap):
-            sample = rs.choice(excesses, size=len(excesses), replace=True)
-            try:
-                bc, _, bscale = genpareto.fit(sample, floc=0)
-                boot_level = threshold + (bscale / bc) * (
-                    (exceed_prob * return_secs) ** bc - 1
-                )
-                boot_levels.append(boot_level)
-            except Exception:
-                continue
-
-        boot_levels = np.array(boot_levels)
-        boot_levels = boot_levels[~np.isnan(boot_levels).any(axis=1)]
-        boot_levels = boot_levels[
-            (boot_levels > -1e6).all(axis=1) & (boot_levels < 1e6).all(axis=1)
-        ]
-
-        if boot_levels.shape[0] > 0:
-            ci_alpha = 100 - self.ci_spin.value()
-            lower_bounds = np.percentile(boot_levels, ci_alpha / 2, axis=0)
-            upper_bounds = np.percentile(boot_levels, 100 - ci_alpha / 2, axis=0)
-        else:
-            lower_bounds = upper_bounds = [np.nan] * len(return_secs)
-
         units = ""
         max_val = np.max(x) if tail == "upper" else np.min(x)
 
         result = f"Extreme value statistics: {self.ts.name}\n\n"
-        result += f"The {return_periods[-2]:.1f} hour return level is\n{rl[-2]:.5f} {units}\n\n"
-        result += f"Fitted GPD parameters:\nSigma: {scale:.4f}\nXi: {c:.4f}\nExceedances used: {len(excesses)}\n"
+        result += (
+            f"The {evm_result.return_periods[-2]:.1f} hour return level is\n"
+            f"{evm_result.return_levels[-2]:.5f} {units}\n\n"
+        )
+        result += (
+            "Fitted GPD parameters:\n"
+            f"Sigma: {scale:.4f}\n"
+            f"Xi: {c:.4f}\n"
+            f"Exceedances used: {len(evm_result.exceedances)}\n"
+        )
         result += f"Total crossings/clusters found: {len(cross_indices) - 1}\n"
         result += f"Observed maximum value: {max_val:.4f} {units}\n"
         result += f"Return level unit: {units or 'same as input'}\n\n"
         result += f"{self.ci_spin.value():.0f}% Confidence Interval:\n"
-        for rp, lo, up in zip(return_periods, lower_bounds, upper_bounds):
+        for rp, lo, up in zip(
+            evm_result.return_periods,
+            evm_result.lower_bounds,
+            evm_result.upper_bounds,
+        ):
             result += f"{rp:.1f} hr: {lo:.3f} – {up:.3f}\n"
 
         self.result_text.setPlainText(result)
 
         self.plot_diagnostics(
-            return_secs,
-            rl,
-            excesses,
+            evm_result.return_periods * 3600,
+            evm_result.return_levels,
+            evm_result.exceedances - threshold,
             c,
             scale,
             threshold,
-            lower_bounds,
-            upper_bounds,
+            evm_result.lower_bounds,
+            evm_result.upper_bounds,
         )
         self._evm_ran = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_evm.py
+++ b/tests/test_evm.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+from anytimes.evm import calculate_extreme_value_statistics, cluster_exceedances
+
+
+def _synthetic_series():
+    rng = np.random.default_rng(42)
+    size = 720
+    base = rng.normal(0, 0.2, size)
+    indices = rng.choice(size, size // 20, replace=False)
+    excess = rng.standard_gamma(2.5, size=indices.size)
+    base[indices] += 1.5 + excess
+    return np.arange(size, dtype=float), base
+
+
+def test_cluster_exceedances_matches_expected_profile():
+    t, x = _synthetic_series()
+    threshold = 1.2
+
+    clusters = cluster_exceedances(x, threshold, "upper")
+
+    assert clusters.size == 35
+    expected_first = np.array(
+        [
+            3.255648,
+            2.516285,
+            4.036607,
+            5.324857,
+            5.090921,
+            5.634556,
+            4.319638,
+            4.548014,
+            3.063981,
+            4.114666,
+        ]
+    )
+    np.testing.assert_allclose(clusters[: expected_first.size], expected_first, rtol=0, atol=1e-6)
+
+
+def test_calculate_extreme_value_statistics_matches_known_values():
+    t, x = _synthetic_series()
+    threshold = 1.2
+
+    res = calculate_extreme_value_statistics(
+        t,
+        x,
+        threshold,
+        tail="upper",
+        confidence_level=90.0,
+        n_bootstrap=200,
+        rng=np.random.default_rng(2024),
+    )
+
+    assert res.exceedances.size == 35
+    assert np.isclose(res.shape, -0.7473962018962973)
+    assert np.isclose(res.scale, 4.591897801701656)
+
+    expected_levels = np.array([6.6211765, 7.12681975, 7.21457406, 7.28698103, 7.30503227])
+    expected_lower = np.array([6.01020245, 6.18871786, 6.19542769, 6.19878085, 6.1993328])
+    expected_upper = np.array([7.08325542, 7.22327264, 7.28170387, 7.40015782, 7.43073501])
+
+    np.testing.assert_allclose(res.return_levels, expected_levels, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(res.lower_bounds, expected_lower, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(res.upper_bounds, expected_upper, rtol=0, atol=1e-6)


### PR DESCRIPTION
## Summary
- add a reusable `anytimes.evm` module that exposes the extreme-value computations used by the GUI
- refactor the Extreme Value Statistics dialog to call the shared implementation and keep its textual/plot outputs in sync
- add deterministic tests that validate the clustered exceedances and return-level estimates against known values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbc433d814832c950d1e4f01b2e34b