### PR TITLE
Refine GPD confidence intervals and add OrcaFlex regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.8"
 dependencies = [
     "numpy",
     "pandas",
+    "openpyxl",
     "scipy",
     "PySide6",
     "matplotlib",

--- a/tests/test_evm.py
+++ b/tests/test_evm.py
@@ -1,5 +1,6 @@
+from pathlib import Path
 import numpy as np
-
+import pandas as pd
 
 from anytimes import evm
 from anytimes.evm import (
@@ -7,8 +8,6 @@ from anytimes.evm import (
     cluster_exceedances,
     declustering_boundaries,
 )
-=======
-
 
 
 def _synthetic_series():
@@ -59,7 +58,7 @@ def test_calculate_extreme_value_statistics_matches_known_values():
         threshold,
         tail="upper",
         confidence_level=90.0,
-        n_bootstrap=200,
+        n_bootstrap=10_000,
         rng=np.random.default_rng(2024),
     )
 
@@ -69,8 +68,8 @@ def test_calculate_extreme_value_statistics_matches_known_values():
     assert np.isclose(res.scale, 4.8572359369876255)
 
     expected_levels = np.array([6.65656619, 7.1321767, 7.20990746, 7.27154184, 7.28629789])
-    expected_lower = np.array([5.85069148, 6.00889926, 6.01775253, 6.03363989, 6.04274598])
-    expected_upper = np.array([7.09042912, 7.22463645, 7.26022048, 7.35106889, 7.38627693])
+    expected_lower = np.array([5.93958204, 6.82033183, 7.01422591, 7.17422058, 7.20959305])
+    expected_upper = np.array([6.97593568, 7.35651581, 7.45919467, 7.57530795, 7.62314262])
 
 
     np.testing.assert_allclose(res.return_levels, expected_levels, rtol=0, atol=1e-6)
@@ -126,4 +125,47 @@ def test_return_levels_lower_tail_reflects_negative_extremes():
     )
 
     np.testing.assert_allclose(calculated, expected, rtol=0, atol=1e-12)
+
+
+def test_extreme_value_statistics_matches_orcaflex_reference():
+    df = pd.read_excel(Path(__file__).with_name("ts_test.xlsx"))
+    t = df["Time"].to_numpy()
+    x = df["In-frame connection moment"].to_numpy()
+
+    rng = np.random.default_rng(321)
+    res = calculate_extreme_value_statistics(
+        t,
+        x,
+        threshold=40_000.0,
+        tail="upper",
+        return_periods_hours=(3,),
+        confidence_level=57.0,
+        n_bootstrap=200_000,
+        rng=rng,
+    )
+
+    assert res.exceedances.size == 59
+    assert np.isclose(res.shape, -0.07282703542815137)
+    assert np.isclose(res.scale, 5391.153396561946)
+
+    target_return_level = 59_019.11922172028
+    assert np.isclose(res.return_levels[0], target_return_level, atol=50.0)
+
+    target_lower = 56_816.934740780554
+    target_upper = 62_741.90315822626
+
+    assert abs(res.lower_bounds[0] - target_lower) < 500.0
+    assert abs(res.upper_bounds[0] - target_upper) < 1_200.0
+
+    covariance = evm._gpd_parameter_covariance(
+        shape=res.shape,
+        scale=res.scale,
+        excesses=res.exceedances - res.threshold,
+    )
+    assert covariance is not None
+    se_shape = float(np.sqrt(covariance[0, 0]))
+    se_scale = float(np.sqrt(covariance[1, 1]))
+
+    assert np.isclose(se_shape, 0.15899, atol=1e-3)
+    assert np.isclose(se_scale, 1106.65, atol=5.0)
 

--- a/tests/test_merge_selected.py
+++ b/tests/test_merge_selected.py
@@ -3,12 +3,15 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+pytest.importorskip("PySide6.QtWidgets", exc_type=ImportError)
 from PySide6.QtWidgets import QWidget
 
 
@@ -49,7 +52,6 @@ for name, module in stub_modules.items():
     sys.modules.setdefault(name, module)
 
 import numpy as np
-import pytest
 from PySide6.QtWidgets import QApplication, QMessageBox
 
 from anytimes.gui.editor import TimeSeriesEditorQt


### PR DESCRIPTION
## Summary
- derive a finite-difference observed-information matrix for the GPD fit and use multivariate-normal sampling to estimate confidence bands without slow bootstrap loops
- add a regression test against the OrcaFlex reference workbook and refresh the synthetic extreme value expectations
- declare the openpyxl dependency and guard GUI tests so they skip cleanly when Qt libraries are unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68dbd3442d80832c9f759c8b77dd72f7