### PR TITLE
Fix PSD plotting in stats dialog

### DIFF
--- a/anytimes/gui/stats_dialog.py
+++ b/anytimes/gui/stats_dialog.py
@@ -426,9 +426,16 @@ class StatsDialog(QDialog):
                 label = f"{file}::{var}"
             ax.plot(t, y, label=label)
             if len(t) > 1:
-                dt = np.median(np.diff(t))
-                fs = 1.0 / dt if dt > 0 else 1.0
-                axp.psd(y, Fs=fs, label=label)
+                ts_tmp = TimeSeries("tmp", t, y)
+                try:
+                    freqs, psd_vals = ts_tmp.psd(resample=ts_tmp.dt)
+                except ValueError:
+                    dt = float(np.median(np.diff(t)))
+                    if dt <= 0:
+                        continue
+                    freqs, psd_vals = ts_tmp.psd(resample=dt)
+                if freqs.size and psd_vals.size:
+                    axp.plot(freqs, psd_vals, label=label)
 
         ax.set_xlabel("Time")
         ax.set_ylabel("Value")
@@ -438,7 +445,7 @@ class StatsDialog(QDialog):
         self._tight_draw(self.line_fig, self.line_canvas)
 
         axp.set_xlabel("Frequency [Hz]")
-        axp.set_ylabel("PSD")
+        axp.set_ylabel("Power spectral density")
         axp.legend()
         axp.grid(True)
 


### PR DESCRIPTION
## Summary
- compute PSD values for the statistics dialog with the TimeSeries Welch-based implementation so the plotted magnitudes match the rest of the app
- update the PSD axis label to clarify the plotted quantity

## Testing
- pytest *(fails: SyntaxError in tests/test_evm.py; ImportError: libGL.so.1 missing for Qt widgets)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe2ced1f4832c838c36e92037e8ec