### PR TITLE
Make EVM bootstrap deterministic

### DIFF
--- a/anytimes/evm.py
+++ b/anytimes/evm.py
@@ -289,7 +289,7 @@ def calculate_extreme_value_statistics(
     upper_bounds = np.full(return_levels.shape, np.nan)
 
     if covariance is not None and n_bootstrap > 0:
-        rng = np.random.default_rng() if rng is None else rng
+        rng = np.random.default_rng(0) if rng is None else rng
         try:
             samples = rng.multivariate_normal(
                 mean=np.array([shape, scale], dtype=float),


### PR DESCRIPTION
## Summary
- seed the bootstrap random number generator used by the EVM utility when no RNG is supplied so repeated runs are reproducible

## Testing
- pytest *(fails: Missing optional dependency 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_68dbed52b24c832cb71b154c0855da40