### PR TITLE
Improve variable pane expansion behaviour

### DIFF
--- a/anytimes/gui/editor.py
+++ b/anytimes/gui/editor.py
@@ -87,7 +87,7 @@ class TimeSeriesEditorQt(QMainWindow):
 
         self._min_left_panel = 240
         self._min_right_panel = 420
-        self._splitter_ratio = 0.35
+        self._splitter_ratio = 0.42
         self._updating_splitter = False
 
 
@@ -137,7 +137,12 @@ class TimeSeriesEditorQt(QMainWindow):
         # -----------------------
         left_widget = QWidget()
         left_widget.setMinimumWidth(self._min_left_panel)
-        left_widget.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
+        # Allow the variable panel to grow when the splitter handle is dragged.
+        # ``Preferred`` prevented the widget from expanding even though the
+        # splitter reported the new size, resulting in the left pane snapping
+        # back to its original width. ``Expanding`` makes the panel honour the
+        # splitter geometry updates while keeping the existing minimum width.
+        left_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         left_layout = QVBoxLayout(left_widget)
 
         # Quick navigation buttons

--- a/anytimes/gui/variable_tab.py
+++ b/anytimes/gui/variable_tab.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
     QScrollArea,
     QVBoxLayout,
     QWidget,
+    QSizePolicy,
 )
 
 from .utils import _matches_terms, _parse_search_terms
@@ -25,9 +26,11 @@ class VariableRowWidget(QWidget):
 
         layout = QHBoxLayout(self)
         self.checkbox = QCheckBox()
+        self.checkbox.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.input = QLineEdit()
         self.input.setFixedWidth(70)
         self.label = QLabel(varname)
+        self.label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
 
         layout.addWidget(self.checkbox)
         layout.addWidget(self.input)
@@ -81,11 +84,15 @@ class VariableTab(QWidget):
         # -- Scrollable area for variable checkboxes --
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
+        scroll.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.inner = QWidget()
+        self.inner.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.MinimumExpanding)
         self.inner_layout = QVBoxLayout(self.inner)
         self._populate_checkboxes(self.all_vars)
         scroll.setWidget(self.inner)
         layout.addWidget(scroll)
+        layout.setStretch(0, 0)
+        layout.setStretch(1, 1)
         # Connections
         self.select_all_btn.clicked.connect(lambda: self.set_all(True))
         self.unselect_all_btn.clicked.connect(lambda: self.set_all(False))


### PR DESCRIPTION
## Summary
- widen the default splitter ratio so the variable pane starts slightly larger
- ensure the variable tab widgets expand with the splitter by updating their size policies

## Testing
- not run (GUI change)

------
https://chatgpt.com/codex/tasks/task_e_68dcde911c54832c83d5ffb1fe56b639