### PR TITLE
Reset save directory when clearing files

### DIFF
--- a/anytimes/gui/editor.py
+++ b/anytimes/gui/editor.py
@@ -2226,6 +2226,8 @@ class TimeSeriesEditorQt(QMainWindow):
     def clear_all_files(self):
         self.tsdbs.clear()
         self.file_paths.clear()
+        self.user_variables.clear()
+        self.work_dir = None
         self.file_list.clear()
         self.refresh_variable_tabs()
 


### PR DESCRIPTION
## Summary
- clear stored user variables and export work directory when clearing all files
- ensure saving or launching exports after clearing prompts for a new destination

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3736aa014832ca158411de96f1752