### PR TITLE
Add PyExtremes engine option to extreme value analysis

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -130,11 +130,13 @@ Selecting **Show statistic for selected variables** opens a table with descripti
 
 ## Extreme Value Statistics Window
 
-Launched from **Open Extreme Value Statistics Tool**, this dialog estimates return levels using a Generalized Pareto distribution. Features include:
+Launched from **Open Extreme Value Statistics Tool**, this dialog estimates return levels using either the built-in SciPy fitter or the optional `pyextremes` engine. Features include:
 
+- Engine selector to switch between the original Generalized Pareto fit and a PyExtremes Peaks-Over-Threshold pipeline.
 - Tail selection (**upper** or **lower**).
 - Threshold spin box with **Calc Threshold** helper.
 - Confidence level input for bootstrap intervals.
+- PyExtremes-specific controls for the declustering window, return-period base and bootstrap sample count.
 - **Run EVM** performs the analysis and updates the result text.
 - Plots of the raw time series with threshold, return level curve and a quantile comparison.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "scipy",
     "PySide6",
     "matplotlib",
+    "pyextremes",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add a PyExtremes-backed execution path to the extreme value calculations while preserving the existing SciPy-based implementation
- expose an engine selector and PyExtremes tuning controls in the GUI along with richer result messaging
- document the new workflow, depend on pyextremes, and extend the unit tests to cover both engines
- normalize the tail argument so either "upper"/"lower" or "high"/"low" labels work consistently across engines

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3990de868832c86242d298379e9e0