### PR TITLE
Add plotting position selector for PyExtremes diagnostics

### DIFF
--- a/anytimes/evm.py
+++ b/anytimes/evm.py
@@ -14,6 +14,19 @@ import numpy as np
 from scipy.stats import genpareto
 
 
+_PYEXTREMES_PLOTTING_POSITIONS = {
+    "ecdf",
+    "hazen",
+    "weibull",
+    "tukey",
+    "blom",
+    "median",
+    "cunnane",
+    "gringorten",
+    "beard",
+}
+
+
 def _gpd_negative_log_likelihood(
     params: np.ndarray, excesses: np.ndarray
 ) -> float:
@@ -495,6 +508,17 @@ def _calculate_extreme_value_statistics_pyextremes(
         "extremes_type": extremes_type,
     }
 
+    plotting_position_opt = options.get("plotting_position", "weibull")
+    if plotting_position_opt is None:
+        plotting_position = "weibull"
+    else:
+        plotting_position = str(plotting_position_opt).lower()
+    if plotting_position not in _PYEXTREMES_PLOTTING_POSITIONS:
+        raise ValueError(
+            f"Unsupported pyextremes plotting_position '{plotting_position_opt}'"
+        )
+    metadata["plotting_position"] = plotting_position
+
     if method == "POT":
         r_value = options.get("r")
         if r_value is None:
@@ -599,6 +623,7 @@ def _calculate_extreme_value_statistics_pyextremes(
             return_period=pyext_return_periods,
             return_period_size=return_period_size,
             alpha=alpha,
+            plotting_position=plotting_position,
         )
     except Exception:  # pragma: no cover - plotting should not fail analysis
         diagnostic_figure = None

--- a/tests/test_evm.py
+++ b/tests/test_evm.py
@@ -283,6 +283,7 @@ def test_pyextremes_engine_returns_consistent_structure():
     assert np.isfinite(res.scale)
     assert res.metadata is not None
     assert "distribution" in res.metadata
+    assert res.metadata.get("plotting_position") == "weibull"
 
 
 @pytest.mark.skipif(pyextremes is None, reason="pyextremes is not installed")
@@ -320,4 +321,45 @@ def test_pyextremes_engine_accepts_low_tail_alias():
     np.testing.assert_allclose(res_low.upper_bounds, res_lower.upper_bounds)
     assert res_low.metadata is not None
     assert res_low.metadata.get("extremes_type") == "low"
+
+
+@pytest.mark.skipif(pyextremes is None, reason="pyextremes is not installed")
+def test_pyextremes_engine_accepts_plotting_position_selection():
+    t, x = _synthetic_series()
+    threshold = 1.2
+
+    res = calculate_extreme_value_statistics(
+        t,
+        x,
+        threshold,
+        tail="upper",
+        return_periods_hours=(0.5, 1.0, 2.0),
+        confidence_level=90.0,
+        engine="pyextremes",
+        pyextremes_options={
+            "r": 1.0,
+            "return_period_size": "1h",
+            "n_samples": 200,
+            "plotting_position": "median",
+        },
+        rng=np.random.default_rng(4321),
+    )
+
+    assert res.metadata is not None
+    assert res.metadata.get("plotting_position") == "median"
+
+
+@pytest.mark.skipif(pyextremes is None, reason="pyextremes is not installed")
+def test_pyextremes_engine_rejects_invalid_plotting_position():
+    t, x = _synthetic_series()
+
+    with pytest.raises(ValueError):
+        calculate_extreme_value_statistics(
+            t,
+            x,
+            threshold=1.2,
+            tail="upper",
+            engine="pyextremes",
+            pyextremes_options={"plotting_position": "invalid"},
+        )
 


### PR DESCRIPTION
## Summary
- add a dedicated plotting position selector to the PyExtremes engine UI
- propagate the chosen plotting position into the pyextremes integration and metadata
- extend tests to cover valid and invalid plotting position options

## Testing
- pytest tests/test_evm.py

------
https://chatgpt.com/codex/tasks/task_e_68e3a8665990832cb50995d8c736545f