### PR TITLE
Allow default diagnostic return periods for pyextremes

### DIFF
--- a/anytimes/evm.py
+++ b/anytimes/evm.py
@@ -597,6 +597,25 @@ def _calculate_extreme_value_statistics_pyextremes(
 
     pyext_return_periods = return_periods / float(base_hours)
 
+    diagnostic_return_periods_opt = options.get(
+        "diagnostic_return_periods", return_periods
+    )
+    if diagnostic_return_periods_opt is None:
+        diagnostic_return_periods = None
+    else:
+        diagnostic_return_periods = np.asarray(
+            tuple(diagnostic_return_periods_opt), dtype=float
+        )
+        if np.any(diagnostic_return_periods <= 0):
+            raise ValueError("diagnostic_return_periods must be positive")
+        diagnostic_return_periods = diagnostic_return_periods / float(base_hours)
+
+    metadata["diagnostic_return_periods"] = (
+        None
+        if diagnostic_return_periods_opt is None
+        else tuple(np.asarray(diagnostic_return_periods_opt, dtype=float))
+    )
+
     alpha = float(confidence_level) / 100.0
     alpha = min(max(alpha, 1e-6), 0.999999)
 
@@ -620,7 +639,7 @@ def _calculate_extreme_value_statistics_pyextremes(
     diagnostic_figure = None
     try:
         diagnostic_figure, _ = eva.plot_diagnostic(
-            return_period=pyext_return_periods,
+            return_period=diagnostic_return_periods,
             return_period_size=return_period_size,
             alpha=alpha,
             plotting_position=plotting_position,

--- a/tests/test_evm.py
+++ b/tests/test_evm.py
@@ -284,6 +284,7 @@ def test_pyextremes_engine_returns_consistent_structure():
     assert res.metadata is not None
     assert "distribution" in res.metadata
     assert res.metadata.get("plotting_position") == "weibull"
+    assert res.metadata.get("diagnostic_return_periods") == (0.5, 1.0, 2.0)
 
 
 @pytest.mark.skipif(pyextremes is None, reason="pyextremes is not installed")
@@ -347,6 +348,32 @@ def test_pyextremes_engine_accepts_plotting_position_selection():
 
     assert res.metadata is not None
     assert res.metadata.get("plotting_position") == "median"
+
+
+@pytest.mark.skipif(pyextremes is None, reason="pyextremes is not installed")
+def test_pyextremes_engine_allows_default_diagnostic_return_periods():
+    t, x = _synthetic_series()
+    threshold = 1.2
+
+    res = calculate_extreme_value_statistics(
+        t,
+        x,
+        threshold,
+        tail="upper",
+        return_periods_hours=(0.5, 1.0, 2.0),
+        confidence_level=90.0,
+        engine="pyextremes",
+        pyextremes_options={
+            "r": 1.0,
+            "return_period_size": "1h",
+            "n_samples": 200,
+            "diagnostic_return_periods": None,
+        },
+        rng=np.random.default_rng(5678),
+    )
+
+    assert res.metadata is not None
+    assert res.metadata.get("diagnostic_return_periods") is None
 
 
 @pytest.mark.skipif(pyextremes is None, reason="pyextremes is not installed")


### PR DESCRIPTION
## Summary
- allow the pyextremes engine to honour custom or default diagnostic return period selections
- persist the diagnostic return periods choice in the result metadata
- add regression coverage for using the default diagnostic return periods

## Testing
- pytest tests/test_evm.py -k pyextremes


------
https://chatgpt.com/codex/tasks/task_e_68e3b370a58c832cbb4aec095ca83772