### PR TITLE
feat: show extremes plot next to EVS results

### DIFF
--- a/anytimes/evm.py
+++ b/anytimes/evm.py
@@ -647,6 +647,7 @@ def _calculate_extreme_value_statistics_pyextremes(
             f"Unsupported pyextremes plotting_position '{plotting_position_opt}'"
         )
     metadata["plotting_position"] = plotting_position
+    metadata["eva"] = eva
 
     if method == "POT":
         r_value = options.get("r")


### PR DESCRIPTION
## Summary
- split the EVS dialog output so the text summary appears beside a dedicated extremes plot canvas
- reuse the existing threshold plot for the built-in engine and draw pyextremes results via `plot_extremes()` when that engine is selected
- retain the EVA instance from pyextremes runs so the GUI can render the library’s extremes plot

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e506f73128832c92379800411cf965