### PR TITLE
Fix frequency-domain .sim time dialog kwargs for PySide

### DIFF
--- a/anytimes/gui/file_loader.py
+++ b/anytimes/gui/file_loader.py
@@ -1810,8 +1810,8 @@ class FileLoader:
             "Frequency-domain .sim sample time",
             "Start time [s] for synthesised time history:",
             value=start_default,
-            min=-1.0e12,
-            max=1.0e12,
+            minValue=-1.0e12,
+            maxValue=1.0e12,
             decimals=3,
         )
         if not ok:
@@ -1822,8 +1822,8 @@ class FileLoader:
             "Frequency-domain .sim sample time",
             "Stop time [s] for synthesised time history:",
             value=stop_default,
-            min=-1.0e12,
-            max=1.0e12,
+            minValue=-1.0e12,
+            maxValue=1.0e12,
             decimals=3,
         )
         if not ok:


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when loading frequency-domain OrcaFlex `.sim` files after variable selection by using the correct `QInputDialog.getDouble` keyword argument names expected by PySide.

### Description
- Replace `min`/`max` kwargs with `minValue`/`maxValue` in the `QInputDialog.getDouble` calls in `anytimes/gui/file_loader.py` for the frequency-domain `.sim` start/stop time prompts.

### Testing
- Ran `pytest -q tests/test_file_loader.py` and the tests completed successfully (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6e4998958832c956d6bf52d565663)