### PR TITLE
Show detailed OrcaFlex preload errors

### DIFF
--- a/anytimes/gui/file_loader.py
+++ b/anytimes/gui/file_loader.py
@@ -146,10 +146,10 @@ class FileLoader:
             except Exception as exc:
                 errors.append((fp, exc))
         if errors:
-            raise RuntimeError(
-                "Models not preloaded: "
-                + ", ".join(os.path.basename(m) for m, _ in errors)
+            details = "\n".join(
+                f"{os.path.basename(path)}: {exc}" for path, exc in errors
             )
+            raise RuntimeError(f"Models not preloaded.\n{details}")
 
 
         dialog = QDialog(self.parent_gui)

--- a/tests/test_file_loader.py
+++ b/tests/test_file_loader.py
@@ -7,6 +7,7 @@ import types
 
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 
@@ -397,6 +398,25 @@ def test_load_orcaflex_time_histories_individually_returns_last_error(monkeypatc
 
     assert isinstance(error, RuntimeError)
     assert str(error) == "not available"
+
+
+def test_open_orcaflex_picker_includes_preload_error_details(monkeypatch):
+    file_loader = _load_file_loader(monkeypatch)
+    loader = file_loader.FileLoader()
+
+    def _fail_load(_self, filepath):
+        raise RuntimeError(
+            f"Problem reading time history file 'missing.txt' while opening '{filepath}'"
+        )
+
+    monkeypatch.setattr(file_loader.FileLoader, "_load_sim_model", _fail_load)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        loader.open_orcaflex_picker(["/tmp/example.sim"])
+
+    message = str(excinfo.value)
+    assert message.startswith("Models not preloaded.\n")
+    assert "example.sim: Problem reading time history file 'missing.txt'" in message
 
 def test_load_era5_netcdf_single_point(monkeypatch, tmp_path):
     file_loader = _load_file_loader(monkeypatch)


### PR DESCRIPTION
### Motivation
- The OrcaFlex picker previously raised a generic `Models not preloaded` error that only listed model basenames, which hid the underlying exceptions (e.g., missing time-history files) from the GUI and made troubleshooting difficult.

### Description
- Update `open_orcaflex_picker` in `anytimes/gui/file_loader.py` to include the original exception text for each failed `.sim` preload by building `"{basename}: {exc}"` lines and raising `RuntimeError` with those details.
- Add a regression test `test_open_orcaflex_picker_includes_preload_error_details` to `tests/test_file_loader.py` that asserts the raised message starts with `Models not preloaded.` and contains the per-file exception text.
- Import `pytest` in the test module to support the new assertion.

### Testing
- Ran `pytest -q tests/test_file_loader.py` which completed successfully with all tests passing (`18 passed`) and only warnings reported; the test covering the new behavior passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc0f443cc832c8a56611aac09d3b5)