### PR TITLE
Add progress reporting and safer progress resets to calculator operation

### DIFF
--- a/anytimes/gui/editor.py
+++ b/anytimes/gui/editor.py
@@ -960,8 +960,13 @@ class TimeSeriesEditorQt(QMainWindow):
         """Evaluate the Calculator expression and create new series."""
         import traceback
 
+        self.progress.setFormat("Calculating %v/%m files")
+        self.update_progressbar(0, max(len(self.tsdbs), 1))
+
         expr = self.calc_entry.toPlainText().strip()
         if not expr:
+            self.progress.reset()
+            self.progress.setFormat("%p%")
             QMessageBox.warning(self, "No Formula", "Please enter a formula.")
             return
 
@@ -1031,6 +1036,8 @@ class TimeSeriesEditorQt(QMainWindow):
             if t_window is not None:
                 break
         if t_window is None:
+            self.progress.reset()
+            self.progress.setFormat("%p%")
             QMessageBox.critical(self, "No Time Window", "Could not infer a valid time window.")
             return
 
@@ -1045,6 +1052,8 @@ class TimeSeriesEditorQt(QMainWindow):
         known_user = getattr(self, "user_variables", set())
         missing = u_global - known_user
         if missing:
+            self.progress.reset()
+            self.progress.setFormat("%p%")
             QMessageBox.critical(self, "Unknown user variable", ", ".join(sorted(missing)))
             return
 
@@ -1078,12 +1087,16 @@ class TimeSeriesEditorQt(QMainWindow):
                     names = None
             v, err = align_all_files(k, name_by_file=names)
             if err:
+                self.progress.reset()
+                self.progress.setFormat("%p%")
                 QMessageBox.critical(self, "Common variable error", err)
                 return
             aligned_common[k] = v
         for k in u_global:
             v, err = align_all_files(k)
             if err:
+                self.progress.reset()
+                self.progress.setFormat("%p%")
                 QMessageBox.critical(self, "User variable error", err)
                 return
             aligned_u_global[k] = v
@@ -1095,10 +1108,14 @@ class TimeSeriesEditorQt(QMainWindow):
                 continue
             src_idx = int(m.group(2)) - 1
             if src_idx >= len(self.tsdbs):
+                self.progress.reset()
+                self.progress.setFormat("%p%")
                 QMessageBox.critical(self, "User variable error", f"File #{m.group(2)} does not exist.")
                 return
             ts = self.tsdbs[src_idx].getm().get(tok)
             if ts is None:
+                self.progress.reset()
+                self.progress.setFormat("%p%")
                 QMessageBox.critical(self, "User variable error", f"Variable '{tok}' not found in {os.path.basename(self.file_paths[src_idx])}")
                 return
             aligned_u_perfile[tok] = _align_to_window(ts, ts.x)
@@ -1106,6 +1123,7 @@ class TimeSeriesEditorQt(QMainWindow):
         create_common_output = len(explicit_file_tags) >= 2
 
         results = []
+        total_files = len(self.tsdbs)
         for file_idx, tsdb in enumerate(self.tsdbs):
             f_no = file_idx + 1
             ctx = {}
@@ -1150,32 +1168,35 @@ class TimeSeriesEditorQt(QMainWindow):
                     raise ValueError("Result length mismatch with time vector")
 
                 must_write_here = (create_common_output and f_no == min(file_tags_used)) or (not create_common_output and f_no in file_tags_used)
-                if not must_write_here:
-                    continue
+                if must_write_here:
+                    filt_tag = self._filter_tag()
+                    suffix = "" if create_common_output else f"_f{f_no}"
+                    out_name = base_output
+                    if filt_tag:
+                        out_name += f"_{filt_tag}"
+                    out_name += suffix
+                    ts_new = qats.TimeSeries(out_name, t_window, y, dtg_ref=t_window_dtg_ref)
 
-                filt_tag = self._filter_tag()
-                suffix = "" if create_common_output else f"_f{f_no}"
-                out_name = base_output
-                if filt_tag:
-                    out_name += f"_{filt_tag}"
-                out_name += suffix
-                ts_new = qats.TimeSeries(out_name, t_window, y, dtg_ref=t_window_dtg_ref)
+                    tsdb.add(ts_new)
 
-                tsdb.add(ts_new)
+                    if create_common_output:
+                        for other_db in self.tsdbs:
+                            if out_name not in other_db.getm():
+                                other_db.add(ts_new.copy())
 
-                if create_common_output:
-                    for other_db in self.tsdbs:
-                        if out_name not in other_db.getm():
-                            other_db.add(ts_new.copy())
-
-                self.user_variables = getattr(self, "user_variables", set())
-                self.user_variables.add(out_name)
-                results.append((tsdb, ts_new))
+                    self.user_variables = getattr(self, "user_variables", set())
+                    self.user_variables.add(out_name)
+                    results.append((tsdb, ts_new))
 
             except Exception as e:
+                self.progress.reset()
+                self.progress.setFormat("%p%")
                 QMessageBox.critical(self, "Calculation Error", f"{os.path.basename(self.file_paths[file_idx])}:\n{e}\n\n{traceback.format_exc()}")
                 return
 
+            self.update_progressbar(file_idx + 1, total_files)
+
+        self.progress.setFormat("%p%")
         self.refresh_variable_tabs()
 
         if create_common_output:


### PR DESCRIPTION
### Motivation
- Provide user feedback while evaluating calculator expressions across multiple files and ensure the progress indicator is left in a consistent state on error or early exit.

### Description
- In `anytimes/gui/editor.py` updated `calculate_series` to initialize the progress display with `self.progress.setFormat("Calculating %v/%m files")` and call `self.update_progressbar(0, max(len(self.tsdbs), 1))` before work begins.
- Reset the progress widget format on early returns and exceptions by calling `self.progress.reset()` and restoring the format to `"%p%"` in error paths and after completion.
- Track `total_files = len(self.tsdbs)` and call `self.update_progressbar(file_idx + 1, total_files)` after each file is processed, and set final format after the loop.
- Reorganized the output creation block to only construct and add output series when `must_write_here` is true, keeping the original semantics but clearer indentation and grouping.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c10c6f6104832cae80d0965f297270)