### PR TITLE
Preserve and load OrcaFlex "Surface Pressures" selections

### DIFF
--- a/anytimes/gui/file_loader.py
+++ b/anytimes/gui/file_loader.py
@@ -1666,8 +1666,6 @@ class FileLoader:
                     obj = _match_obj(obj_name)
                 else:
                     continue
-                if isinstance(var, str) and var.strip().lower() == "surface pressures":
-                    continue
                 if obj is None:
                     continue
                 short_obj = self._strip_redundant(obj_name, redundant_subs)

--- a/tests/test_file_loader.py
+++ b/tests/test_file_loader.py
@@ -261,6 +261,65 @@ def test_is_frequency_domain_model_rejects_time_domain_method(monkeypatch):
     assert loader._is_frequency_domain_model(_Model()) is False
 
 
+def test_load_orcaflex_data_keeps_surface_pressures_selection(monkeypatch):
+    file_loader = _load_file_loader(monkeypatch)
+    loader = file_loader.FileLoader()
+
+    class _General:
+        DynamicsSolutionMethod = "Implicit time domain"
+
+        @staticmethod
+        def TimeHistory(var_name, _time_spec):
+            assert var_name == "Time"
+            return np.array([0.0, 1.0])
+
+    class _Obj:
+        def __init__(self, name):
+            self.Name = name
+            self.typeName = "Vessel"
+
+    class _Model:
+        simulationStartTime = 0.0
+        simulationStopTime = 1.0
+
+        def __init__(self):
+            self.objects = [_Obj("AQ_C2_floater_fwd")]
+
+        def __getitem__(self, key):
+            if key == "General":
+                return _General()
+            if key == "AQ_C2_floater_fwd":
+                return self.objects[0]
+            raise KeyError(key)
+
+    def _specified_period(start, stop):
+        return ("period", float(start), float(stop))
+
+    def _time_history_specification(obj, var, end=None):
+        return (obj.Name, var, end)
+
+    def _get_multiple_time_histories(specs, time_spec):
+        assert time_spec == ("period", 0.0, 1.0)
+        assert specs == [("AQ_C2_floater_fwd", "Surface Pressures", None)]
+        return np.array([[10.0], [12.0]])
+
+    fake_orcfx = types.SimpleNamespace(
+        SpecifiedPeriod=_specified_period,
+        TimeHistorySpecification=_time_history_specification,
+        GetMultipleTimeHistories=_get_multiple_time_histories,
+    )
+    monkeypatch.setitem(sys.modules, "OrcFxAPI", fake_orcfx)
+
+    model = _Model()
+    tsdb = loader._load_orcaflex_data_from_specs(
+        model,
+        [("AQ_C2_floater_fwd", "Surface Pressures", None, None)],
+    )
+
+    assert tsdb is not None
+    assert "AQ_C2_floater_fwd:Surface Pressures" in tsdb.register
+
+
 
 
 def test_extract_model_time_uses_sample_times_for_frequency_domain(monkeypatch):


### PR DESCRIPTION
### Motivation
- The OrcaFlex picker previously omitted `Surface Pressures` selections when building time-history requests, which led to an empty variable list after pressing `Load` if only surface pressures were chosen.

### Description
- Removed the special-case filter that skipped `Surface Pressures` in `FileLoader._load_orcaflex_data_from_specs` so selected surface-pressure variables are forwarded to OrcFxAPI extraction.
- Added a regression test `test_load_orcaflex_data_keeps_surface_pressures_selection` that fakes minimal `OrcFxAPI` behaviour and asserts a `Surface Pressures` timeseries appears in the returned `TsDB`.
- Changes touched `anytimes/gui/file_loader.py` and `tests/test_file_loader.py`.

### Testing
- Ran `pytest -q tests/test_file_loader.py` which completed successfully with all tests passing (`22 passed, 14 warnings`).
- The new regression test `test_load_orcaflex_data_keeps_surface_pressures_selection` passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca7572af4c832c9fb275867d29f00e)