### PR TITLE
Auto-extract Surface Pressures via diffraction model on load

### DIFF
--- a/anytimes/gui/file_loader.py
+++ b/anytimes/gui/file_loader.py
@@ -1152,6 +1152,15 @@ class FileLoader:
                 tsdb = TsDB()
 
             entries = panel_pressure_by_file.get(fp, [])
+            if specs and not entries:
+                extracted = self._auto_extract_surface_pressures_from_specs(
+                    filepath=fp,
+                    model=self.loaded_sim_models[fp],
+                    specs=specs,
+                    parent=dialog,
+                )
+                if extracted is not None:
+                    entries = [extracted]
             for entry in entries:
                 tsdb = self._merge_panel_pressures(
                     tsdb, entry.get("data"), entry.get("info")
@@ -1159,6 +1168,128 @@ class FileLoader:
 
             result[fp] = tsdb
         return result
+
+    def _get_surface_pressure_requests_from_specs(self, specs):
+        body_names = []
+        panel_coords = []
+        for spec in specs or []:
+            if len(spec) < 2:
+                continue
+            obj_name = spec[0] if isinstance(spec[0], str) else spec[1]
+            var = spec[1] if isinstance(spec[0], str) else spec[2]
+            extra = spec[2] if isinstance(spec[0], str) else spec[3]
+            if not isinstance(var, str) or var.strip().lower() != "surface pressures":
+                continue
+            if isinstance(obj_name, str) and obj_name:
+                body_names.append(obj_name)
+            coord = None
+            if isinstance(extra, (tuple, list, np.ndarray)) and len(extra) == 3:
+                coord = tuple(float(v) for v in extra)
+            elif extra is not None:
+                xyz = (
+                    getattr(extra, "X", None),
+                    getattr(extra, "Y", None),
+                    getattr(extra, "Z", None),
+                )
+                if all(v is not None for v in xyz):
+                    try:
+                        coord = tuple(float(v) for v in xyz)
+                    except (TypeError, ValueError):
+                        coord = None
+            if coord is not None:
+                panel_coords.append(coord)
+        if not body_names:
+            return None, []
+        unique_bodies = list(dict.fromkeys(body_names))
+        unique_coords = list(dict.fromkeys(panel_coords))
+        return unique_bodies, unique_coords
+
+    def _select_diffraction_model_path(self, filepath, parent=None):
+        start_dir = self._last_diffraction_dir or os.path.dirname(filepath)
+        if not start_dir or not os.path.isdir(start_dir):
+            start_dir = os.path.dirname(filepath)
+        file_path, _ = QFileDialog.getOpenFileName(
+            parent or self.parent_gui,
+            "Select Diffraction Model (.owr)",
+            start_dir,
+            "Diffraction data (*.owr)",
+        )
+        if not file_path:
+            return None
+        directory = os.path.dirname(file_path)
+        if directory:
+            self._last_diffraction_dir = directory
+        return file_path
+
+    def _auto_extract_surface_pressures_from_specs(self, filepath, model, specs, parent=None):
+        body_names, panel_coords = self._get_surface_pressure_requests_from_specs(specs)
+        if not body_names:
+            return None
+
+        file_path = self._select_diffraction_model_path(filepath, parent=parent)
+        if not file_path:
+            return None
+
+        try:
+            import OrcFxAPI
+            diffraction_model = self._diffraction_cache.get(file_path)
+            if diffraction_model is None:
+                diffraction_model = OrcFxAPI.Diffraction(file_path)
+                self._diffraction_cache[file_path] = diffraction_model
+            pressure_df, panel_info = self._get_panel_pressure(
+                model=model,
+                diffraction_model=diffraction_model,
+                panel_coords=tuple(panel_coords) if panel_coords else None,
+            )
+        except Exception as exc:
+            QMessageBox.critical(
+                parent or self.parent_gui,
+                "Surface Pressure Error",
+                f"Failed to extract surface pressures:\n{exc}",
+            )
+            return None
+
+        if panel_info is None:
+            panel_info = pd.DataFrame()
+        else:
+            panel_info = panel_info.copy().reset_index(drop=True)
+
+        if not panel_info.empty and "name" in panel_info.columns:
+            mask = panel_info["name"].isin(body_names)
+            panel_info = panel_info.loc[mask].reset_index(drop=True)
+            if (
+                pressure_df is not None
+                and not pressure_df.empty
+                and "Time" in pressure_df.columns
+                and "pidx" in panel_info.columns
+            ):
+                allowed_cols = {
+                    str(int(pidx) + 1)
+                    for pidx in panel_info["pidx"].dropna().tolist()
+                }
+                keep_cols = ["Time"] + [
+                    c for c in pressure_df.columns if c != "Time" and c in allowed_cols
+                ]
+                pressure_df = pressure_df[keep_cols]
+
+        if (
+            pressure_df is None
+            or pressure_df.empty
+            or ("Time" in pressure_df.columns and pressure_df.shape[1] <= 1)
+            or ("Time" not in pressure_df.columns and pressure_df.shape[1] == 0)
+        ):
+            QMessageBox.warning(
+                parent or self.parent_gui,
+                "No Surface Pressures",
+                "No surface pressure data was returned for the selected variable.",
+            )
+            return None
+
+        return {
+            "data": pressure_df.copy(),
+            "info": panel_info.copy(),
+            "diffraction_path": file_path,
+        }
 
     def _merge_panel_pressures(self, tsdb, pressures_df, panel_info):
         if tsdb is None:
@@ -1666,6 +1797,11 @@ class FileLoader:
                     obj = _match_obj(obj_name)
                 else:
                     continue
+                # ``Surface Pressures`` is a calculated quantity in this GUI,
+                # populated via the dedicated extraction workflow
+                # (``Extract Surface Pressures``). OrcaFlex time-history reads
+                # can reject it as an unknown variable name (error 26), so skip
+                # direct retrieval here.
                 if isinstance(var, str) and var.strip().lower() == "surface pressures":
                     continue
                 if obj is None:

--- a/tests/test_file_loader.py
+++ b/tests/test_file_loader.py
@@ -261,6 +261,133 @@ def test_is_frequency_domain_model_rejects_time_domain_method(monkeypatch):
     assert loader._is_frequency_domain_model(_Model()) is False
 
 
+def test_load_orcaflex_data_skips_surface_pressures_selection(monkeypatch):
+    file_loader = _load_file_loader(monkeypatch)
+    loader = file_loader.FileLoader()
+
+    class _General:
+        DynamicsSolutionMethod = "Implicit time domain"
+
+        @staticmethod
+        def TimeHistory(var_name, _time_spec):
+            assert var_name == "Time"
+            return np.array([0.0, 1.0])
+
+    class _Obj:
+        def __init__(self, name):
+            self.Name = name
+            self.typeName = "Vessel"
+
+    class _Model:
+        simulationStartTime = 0.0
+        simulationStopTime = 1.0
+
+        def __init__(self):
+            self.objects = [_Obj("AQ_C2_floater_fwd")]
+
+        def __getitem__(self, key):
+            if key == "General":
+                return _General()
+            if key == "AQ_C2_floater_fwd":
+                return self.objects[0]
+            raise KeyError(key)
+
+    def _specified_period(start, stop):
+        return ("period", float(start), float(stop))
+
+    called = {"specs_requested": False}
+
+    def _get_multiple_time_histories(specs, time_spec):
+        called["specs_requested"] = True
+        raise AssertionError("GetMultipleTimeHistories should not be called for skipped surface pressures")
+
+    fake_orcfx = types.SimpleNamespace(
+        SpecifiedPeriod=_specified_period,
+        GetMultipleTimeHistories=_get_multiple_time_histories,
+    )
+    monkeypatch.setitem(sys.modules, "OrcFxAPI", fake_orcfx)
+
+    model = _Model()
+    tsdb = loader._load_orcaflex_data_from_specs(
+        model,
+        [("AQ_C2_floater_fwd", "Surface Pressures", None, None)],
+    )
+
+    assert tsdb is not None
+    assert tsdb.register == {}
+    assert called["specs_requested"] is False
+
+
+def test_get_surface_pressure_requests_from_specs_extracts_bodies_and_coords(monkeypatch):
+    file_loader = _load_file_loader(monkeypatch)
+    loader = file_loader.FileLoader()
+
+    extra = types.SimpleNamespace(X=1.0, Y=2.0, Z=3.0)
+    bodies, coords = loader._get_surface_pressure_requests_from_specs(
+        [
+            ("BodyA", "Surface Pressures", extra, None),
+            ("BodyB", "Surface Pressures", (4.0, 5.0, 6.0), None),
+            ("BodyA", "Axial Tension", None, None),
+        ]
+    )
+
+    assert bodies == ["BodyA", "BodyB"]
+    assert coords == [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)]
+
+
+def test_auto_extract_surface_pressures_from_specs_calls_panel_pressure(monkeypatch):
+    file_loader = _load_file_loader(monkeypatch)
+    loader = file_loader.FileLoader()
+
+    monkeypatch.setattr(
+        loader,
+        "_select_diffraction_model_path",
+        lambda *_args, **_kwargs: "/tmp/model.owr",
+    )
+
+    fake_orcfx = types.SimpleNamespace(
+        Diffraction=lambda path: {"path": path},
+    )
+    monkeypatch.setitem(sys.modules, "OrcFxAPI", fake_orcfx)
+
+    captured = {}
+
+    def _fake_get_panel_pressure(**kwargs):
+        captured.update(kwargs)
+        pressure_df = pd.DataFrame(
+            {"1": [10.0, 11.0], "2": [20.0, 21.0], "Time": [0.0, 1.0]}
+        )
+        panel_info = pd.DataFrame(
+            {
+                "name": ["BodyA", "BodyB"],
+                "pidx": [0, 1],
+                "X": [0.0, 0.0],
+                "Y": [0.0, 0.0],
+                "Z": [0.0, 0.0],
+            }
+        )
+        return pressure_df, panel_info
+
+    monkeypatch.setattr(loader, "_get_panel_pressure", _fake_get_panel_pressure)
+
+    model = object()
+    out = loader._auto_extract_surface_pressures_from_specs(
+        filepath="demo.sim",
+        model=model,
+        specs=[
+            ("BodyA", "Surface Pressures", types.SimpleNamespace(X=1.0, Y=2.0, Z=3.0), None),
+            ("BodyB", "Surface Pressures", None, None),
+        ],
+        parent=None,
+    )
+
+    assert out is not None
+    assert captured["model"] is model
+    assert captured["diffraction_model"] == {"path": "/tmp/model.owr"}
+    assert captured["panel_coords"] == ((1.0, 2.0, 3.0),)
+    assert list(out["data"].columns) == ["Time", "1", "2"]
+    assert out["info"]["name"].tolist() == ["BodyA", "BodyB"]
+
 
 
 def test_extract_model_time_uses_sample_times_for_frequency_domain(monkeypatch):


### PR DESCRIPTION
### Motivation
- `Surface Pressures` selections were still producing empty loads unless users manually ran the dedicated extraction workflow because the quantity is calculated from panel pressures and requires a diffraction model to extract.
- The loader must call the panel-pressure extraction path (`_get_panel_pressure`) with the correct diffraction model and parsed coordinates when `Surface Pressures` is requested so users can load it directly from the picker.

### Description
- Automatically trigger extraction when `Surface Pressures` is present in the selection and no manual extraction payload exists by calling `_auto_extract_surface_pressures_from_specs` from the picker load flow.
- Added `
  _get_surface_pressure_requests_from_specs(specs)
` to parse selection specs and extract requested body names and optional XYZ coordinates from object extras.
- Added `
  _select_diffraction_model_path(filepath, parent)
` helper to prompt for a diffraction model and cache the selected directory.
- Added `
  _auto_extract_surface_pressures_from_specs(filepath, model, specs, parent)
` which loads/uses a diffraction model, calls `_get_panel_pressure(model=..., diffraction_model=..., panel_coords=...)`, filters extracted panel metadata/time-series to the requested bodies, and returns a dictionary suitable for `_merge_panel_pressures`.
- Kept direct OrcaFlex time-history loading for `Surface Pressures` disabled (still skipped in `_load_orcaflex_data_from_specs` to avoid OrcaFlex error 26), but ensured the extraction path is invoked when appropriate so `_get_panel_pressure(...)` receives the required `diffraction_model` and `panel_coords`.

### Testing
- Added `tests/test_file_loader.py::test_get_surface_pressure_requests_from_specs_extracts_bodies_and_coords` to validate parsing of bodies and coordinates from specs, and `tests/test_file_loader.py::test_auto_extract_surface_pressures_from_specs_calls_panel_pressure` to validate wiring to `_get_panel_pressure` and filtering of returned data.
- Ran `pytest -q tests/test_file_loader.py` and all tests passed (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca7572af4c832c9fb275867d29f00e)