### PR TITLE
Preserve explicitly referenced `fN_var` calculator inputs when alignment yields no overlap

### DIFF
--- a/anytimes/gui/editor.py
+++ b/anytimes/gui/editor.py
@@ -1358,6 +1358,7 @@ class TimeSeriesEditorQt(QMainWindow):
             for src_idx, db in enumerate(self.tsdbs):
                 tag = f"f{src_idx + 1}"
                 source_names = explicit_var_names.get(src_idx)
+                keep_empty_alignment = source_names is not None
                 items = (
                     ((name, db.getm()[name]) for name in source_names)
                     if source_names is not None
@@ -1365,7 +1366,7 @@ class TimeSeriesEditorQt(QMainWindow):
                 )
                 for key, ts in items:
                     x_part = _align_to_window(ts, filtered_series_cache[src_idx][key], target_time, target_coord)
-                    if np.all(np.isnan(x_part)):
+                    if np.all(np.isnan(x_part)) and not keep_empty_alignment:
                         continue
                     shared_ctx[f"{tag}_{_safe(key)}"] = x_part.astype(float)
 


### PR DESCRIPTION
### Motivation
- Ensure calculator expressions that explicitly reference `fN_var` variables (e.g. `f3_P4_OUT`) do not raise `NameError` when the alignment against the current target file window produces all-`NaN` values. 

### Description
- When building the calculator `shared_ctx`, keep entries for explicitly referenced variables by setting `keep_empty_alignment = source_names is not None` and only skipping a series if it is all-`NaN` and not explicitly requested, so `fN_*` names remain defined in the evaluation context (`anytimes/gui/editor.py` lines around the alignment loop).

### Testing
- Ran `python -m compileall anytimes/gui/editor.py` which succeeded. 
- Ran `pytest -q tests/test_timeseries_datetime.py` which passed (5 tests, 2 warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccd4574d80832c80ffb24d2b3dc1d2)