### PR TITLE
Support long-format CSV imports keyed by referenceTime and elementId

### DIFF
--- a/anyqats/io/csv.py
+++ b/anyqats/io/csv.py
@@ -4,6 +4,54 @@ Readers CSV formatted time series files
 import pandas as pd
 
 
+def _find_time_column(df):
+    """Return preferred time column name."""
+    lower_to_col = {str(col).strip().lower(): col for col in df.columns}
+    for key in ("time", "t", "referencetime", "reference_time", "datetime", "date"):
+        if key in lower_to_col:
+            return lower_to_col[key]
+
+    for col in df.columns:
+        col_lower = str(col).strip().lower()
+        if "time" in col_lower:
+            return col
+
+    return df.columns[0]
+
+
+def _prepare_table(df):
+    """
+    Normalize CSV data to a wide table where:
+      * first column is time
+      * remaining columns are numeric series
+    """
+    time_col = _find_time_column(df)
+    lowered = {str(col).strip().lower(): col for col in df.columns}
+
+    value_col = lowered.get("value")
+    variable_col = None
+    for candidate in ("elementid", "element_id", "variable", "name"):
+        if candidate in lowered:
+            variable_col = lowered[candidate]
+            break
+
+    if value_col is not None and variable_col is not None:
+        long_df = df[[time_col, variable_col, value_col]].copy()
+        long_df[value_col] = pd.to_numeric(long_df[value_col], errors="coerce")
+        long_df = long_df.dropna(subset=[value_col])
+        if not long_df.empty:
+            wide = long_df.pivot_table(
+                index=time_col,
+                columns=variable_col,
+                values=value_col,
+                aggfunc="first",
+            ).reset_index()
+            wide.columns.name = None
+            return wide, time_col
+
+    return df, time_col
+
+
 def read_names(path):
     """
     Read time series names from a comma-separated file.
@@ -25,8 +73,8 @@ def read_names(path):
     """
     # pandas will infer the format e.g. delimiter.
     df = pd.read_csv(path, sep=None, engine='python', encoding='utf-8')
-    names = list(df)
-    _ = names.pop(0)    # remove time which is assumed to be in the first column
+    df, time_col = _prepare_table(df)
+    names = [name for name in df.columns if name != time_col]
 
     numeric_names = []
     for name in names:
@@ -56,14 +104,15 @@ def read_data(path, ind=None):
 
     """
     df = pd.read_csv(path, sep=None, engine='python')  # pandas will infer the format e.g. delimiter.
+    df, time_col = _prepare_table(df)
 
     if ind is None:
-        cols = list(df.columns[1:])
+        cols = [col for col in df.columns if col != time_col]
     else:
         cols = list(ind)
 
-    # Keep first column (time) and selected numeric data columns.
-    filtered_cols = [df.columns[0]]
+    # Keep selected time column and selected numeric data columns.
+    filtered_cols = [time_col]
     for col in cols:
         if col in df and pd.to_numeric(df[col], errors='coerce').notna().any():
             filtered_cols.append(col)

--- a/tests/test_csv_loader.py
+++ b/tests/test_csv_loader.py
@@ -37,3 +37,37 @@ def test_tsdb_csv_loader_skips_string_columns(tmp_path, monkeypatch):
     assert set(data) == {"hs", "tp"}
     np.testing.assert_allclose(data["hs"].x, np.array([0.027045375, 0.02169195]))
     np.testing.assert_allclose(data["tp"].x, np.array([1.3719087, 1.2471896]))
+
+
+def test_tsdb_csv_loader_supports_long_met_format(tmp_path, monkeypatch):
+    for name in ["h5py", "pymatreader", "nptdms"]:
+        if name not in sys.modules:
+            module = types.ModuleType(name)
+            if name == "pymatreader":
+                module.read_mat = lambda *args, **kwargs: {}
+            if name == "nptdms":
+                module.TdmsFile = type("TdmsFile", (), {})
+            monkeypatch.setitem(sys.modules, name, module)
+
+    from anyqats.tsdb import TsDB
+
+    csv_path = tmp_path / "met_long.csv"
+    csv_path.write_text(
+        "elementId\tvalue\tunit\tlevel\ttimeOffset\ttimeResolution\ttimeSeriesId\tperformanceCategory\texposureCategory\tqualityCode\treferenceTime\tsourceId\n"
+        "wind_from_direction\t330\tdegrees\t{'levelType': 'height_above_ground', 'unit': 'm', 'value': 10}\tPT0H\tPT6H\t0\tC\t2\t2\t1976-04-20T00:00:00.000Z\tSN75550:0\n"
+        "wind_speed\t11.3\tm/s\t{'levelType': 'height_above_ground', 'unit': 'm', 'value': 10}\tPT0H\tPT6H\t0\tC\t2\t2\t1976-04-20T00:00:00.000Z\tSN75550:0\n"
+        "wind_from_direction\t320\tdegrees\t{'levelType': 'height_above_ground', 'unit': 'm', 'value': 10}\tPT0H\tPT6H\t0\tC\t2\t2\t1976-04-20T06:00:00.000Z\tSN75550:0\n"
+        "wind_speed\t10.3\tm/s\t{'levelType': 'height_above_ground', 'unit': 'm', 'value': 10}\tPT0H\tPT6H\t0\tC\t2\t2\t1976-04-20T06:00:00.000Z\tSN75550:0\n",
+        encoding="utf-8",
+    )
+
+    tsdb = TsDB()
+    tsdb.load(str(csv_path), read=False)
+
+    names = tsdb.list(relative=True, display=False)
+    assert names == ["wind_from_direction", "wind_speed"]
+
+    data = tsdb.getm()
+    np.testing.assert_allclose(data["wind_from_direction"].x, np.array([330.0, 320.0]))
+    np.testing.assert_allclose(data["wind_speed"].x, np.array([11.3, 10.3]))
+    assert data["wind_speed"].dtg_time[0].isoformat().startswith("1976-04-20T00:00:00")


### PR DESCRIPTION
### Motivation
- CSV loader previously assumed the first column is the time column which caused files where the first column is `elementId` to be misinterpreted as time and trigger `TypeError: time must be given as array of floats or datetime objects`.
- The change aims to correctly detect time-like columns (including `referenceTime`) and support long (row-based) MET-style CSV tables with `elementId`/`value` pairs.

### Description
- Added `_find_time_column` to detect a preferred time column name (accepts `time`, `t`, `referenceTime`, `reference_time`, `datetime`, `date`, and other columns containing `time`).
- Added `_prepare_table` which detects long-format tables with a `value` and `elementId`-style variable column and pivots them into a wide table indexed by the detected time column while coercing `value` to numeric and dropping non-numeric rows.
- Updated `read_names` and `read_data` to call `_prepare_table` so wide CSVs keep previous behavior and long-format MET CSVs are normalized before TsDB ingestion.
- Added `test_tsdb_csv_loader_supports_long_met_format` in `tests/test_csv_loader.py` and modified tests to validate variable extraction and datetime handling.

### Testing
- Ran `pytest -q tests/test_csv_loader.py` which completed successfully with `2 passed` and two non-fatal SyntaxWarnings reported.
- Modified files: `anyqats/io/csv.py` and `tests/test_csv_loader.py`, and the new behavior is exercised by the added test which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d615c2d6c8832c83897a402d2d1ce3)