### PR TITLE
Fix datetime time-window filtering for referenced time axes

### DIFF
--- a/anytimes/gui/editor.py
+++ b/anytimes/gui/editor.py
@@ -6717,8 +6717,15 @@ class TimeSeriesEditorQt(QMainWindow):
             return np.zeros(0, dtype=bool)
 
         t_arr = np.asarray(t)
+        t_dt = None
         if np.issubdtype(t_arr.dtype, np.datetime64):
             t_dt = pd.to_datetime(t_arr, errors="coerce").to_numpy(dtype="datetime64[ns]")
+        elif getattr(ts, "dtg_time", None) is not None:
+            t_dt = pd.to_datetime(np.asarray(ts.dtg_time), errors="coerce").to_numpy(
+                dtype="datetime64[ns]"
+            )
+
+        if t_dt is not None:
             if t_dt.size == 0:
                 return np.zeros(0, dtype=bool)
 

--- a/tests/test_merge_selected.py
+++ b/tests/test_merge_selected.py
@@ -581,6 +581,24 @@ def test_merge_preserves_datetime_reference(qt_app, message_spy, monkeypatch):
     assert not message_spy["crit"]
     assert not message_spy["warn"]
 
+
+def test_time_window_filters_series_with_datetime_reference(qt_app, monkeypatch):
+    dt_index = pd.date_range("2024-01-01 00:00:00", periods=6, freq="H")
+    ts = TimeSeries("wind_speed", dt_index, np.arange(6, dtype=float))
+    editor = _build_editor(monkeypatch, [DummyDB({"wind_speed": ts})], ["file1.ts"])
+
+    editor.time_start.setText("2024-01-01 01:00:00")
+    editor.time_end.setText("2024-01-01 03:00:00")
+
+    mask = editor.get_time_window(ts)
+    if isinstance(mask, slice):
+        idx = np.arange(ts.t.size)[mask]
+    else:
+        idx = np.flatnonzero(mask)
+
+    np.testing.assert_array_equal(idx, np.array([1, 2, 3]))
+
+
 def test_export_selected_to_csv_uses_shared_time_column(qt_app, message_spy, monkeypatch, tmp_path):
     t = np.array([0.0, 1.0, 2.0])
     tsdb = DummyDB(


### PR DESCRIPTION
### Motivation
- The editor `get_time_window` only handled true `numpy.datetime64` time arrays when parsing Start/End datetime text, causing series that use a numeric time axis with a separate datetime reference (`dtg_time`/`dtg_ref`) to ignore datetime window input. 
- This made the Start/End datetime fields ineffective for many `TimeSeries` instances that carry a referenced datetime axis.

### Description
- Update `TimeSeriesEditorQt.get_time_window` to also build `t_dt` from `ts.dtg_time` when present so referenced datetime axes are treated like native datetime arrays when parsing the time window (`anytimes/gui/editor.py`).
- Preserve existing behavior for native `numpy.datetime64` time arrays and numeric axes when no `dtg_time` is available.
- Add a regression test `test_time_window_filters_series_with_datetime_reference` that creates a `TimeSeries` from a `DatetimeIndex`, sets Start/End text on the editor, and asserts the returned window selects the expected indices (`tests/test_merge_selected.py`).

### Testing
- Ran `pytest -q tests/test_timeseries_datetime.py` and all tests passed (`5 passed`).
- Ran `pytest -q tests/test_merge_selected.py -k "datetime_reference or time_window_filters_series_with_datetime_reference"` in this environment and the run was skipped due to the Qt test environment, so the GUI test was not executed here (`1 skipped`).
- The change is unit-tested by the added regression test `tests/test_merge_selected.py::test_time_window_filters_series_with_datetime_reference`, which will exercise the fix in a full test environment with Qt available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d793231a7c832c8437e391239b00da)