### PR TITLE
Harden Norkyst coordinate alias handling for lat/lon datasets

### DIFF
--- a/env_prediction/norkyst800_data.py
+++ b/env_prediction/norkyst800_data.py
@@ -25,6 +25,20 @@ def _first_existing_name(candidates: Iterable[str], available: Iterable[str]) ->
     return None
 
 
+def _safe_get_coord_or_var(ds: xr.Dataset, name: str) -> xr.DataArray | None:
+    """Return a coordinate or variable without triggering eager fallback lookups.
+
+    Using ``dict.get(name, ds[name])`` is unsafe here because the fallback
+    expression is evaluated eagerly and can raise ``KeyError`` even when the
+    key exists in the first mapping.
+    """
+    if name in ds.coords:
+        return ds.coords[name]
+    if name in ds.variables:
+        return ds[name]
+    return None
+
+
 def _pick_coords(ds: xr.Dataset, var_name: str) -> tuple[np.ndarray, np.ndarray]:
     da = ds[var_name]
     coord_candidates_lon = ("lon", "longitude", "xlon", "nav_lon")
@@ -43,8 +57,16 @@ def _pick_coords(ds: xr.Dataset, var_name: str) -> tuple[np.ndarray, np.ndarray]
             "Expected one of: lon/longitude/nav_lon and lat/latitude/nav_lat."
         )
 
-    lon = ds[lon_name].values
-    lat = ds[lat_name].values
+    lon_da = _safe_get_coord_or_var(ds, lon_name)
+    lat_da = _safe_get_coord_or_var(ds, lat_name)
+    if lon_da is None or lat_da is None:
+        raise ValueError(
+            "Found coordinate aliases but could not access longitude/latitude arrays. "
+            f"Available coords: {list(ds.coords)}; variables: {list(ds.variables)}"
+        )
+
+    lon = lon_da.values
+    lat = lat_da.values
     return lon, lat
 
 

--- a/tests/test_norkyst800_data.py
+++ b/tests/test_norkyst800_data.py
@@ -1,0 +1,32 @@
+import numpy as np
+import xarray as xr
+
+from env_prediction.norkyst800_data import _pick_coords
+
+
+def test_pick_coords_supports_lat_lon_aliases_from_dataset_variables():
+    ds = xr.Dataset(
+        data_vars={
+            "wind_speed_10m": (("y", "x"), np.ones((2, 3))),
+            "lat": (("y", "x"), np.array([[64.9, 64.9, 64.9], [65.0, 65.0, 65.0]])),
+            "lon": (("y", "x"), np.array([[11.0, 11.1, 11.2], [11.0, 11.1, 11.2]])),
+        }
+    )
+
+    lon, lat = _pick_coords(ds, "wind_speed_10m")
+
+    assert lon.shape == (2, 3)
+    assert lat.shape == (2, 3)
+    np.testing.assert_allclose(lon[0], [11.0, 11.1, 11.2])
+
+
+def test_pick_coords_supports_latitude_longitude_coords():
+    ds = xr.Dataset(
+        data_vars={"mwd": (("time", "latitude", "longitude"), np.ones((2, 1, 1)))},
+        coords={"time": [0, 1], "latitude": [60.0], "longitude": [5.0]},
+    )
+
+    lon, lat = _pick_coords(ds, "mwd")
+
+    np.testing.assert_allclose(lon, [5.0])
+    np.testing.assert_allclose(lat, [60.0])


### PR DESCRIPTION
### Motivation
- Prevent a `KeyError` when resolving latitude/longitude aliases in NetCDF datasets where spatial axes appear as coordinates or as data variables by avoiding eager fallback lookups that evaluate `ds[name]` unnecessarily.
- Improve diagnostics and resilience when `_pick_coords` finds alias names but cannot actually access the underlying arrays.

### Description
- Add helper ` _safe_get_coord_or_var(ds, name)` to return a coordinate or variable only after checking membership, avoiding eager fallback evaluation.
- Update `_pick_coords` to use ` _safe_get_coord_or_var` and raise a clearer `ValueError` listing available coords/variables when alias resolution and access diverge.
- Add regression tests in `tests/test_norkyst800_data.py` covering datasets with `lat`/`lon` as data variables and datasets with `latitude`/`longitude` coordinates.

### Testing
- Ran `pytest -q tests/test_norkyst800_data.py` and the test suite completed successfully with `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5236eb1e8832ca7e1536c77536679)