### PR TITLE
Add SWANtool post-processing dialog and integrate into TimeSeriesEditor

### DIFF
--- a/anytimes/gui/editor.py
+++ b/anytimes/gui/editor.py
@@ -76,6 +76,7 @@ from .evm_window import EVMWindow
 from .rao_dialog import RAODialog
 from ..fatigue import FatigueSeries
 from .fatigue_dialog import FatigueDialog
+from .swan_tool_dialog import SWANToolDialog
 from .sortable_table_widget_item import SortableTableWidgetItem
 from .variable_tab import VariableRowWidget, VariableTab
 
@@ -640,9 +641,11 @@ class TimeSeriesEditorQt(QMainWindow):
         self.launch_qats_btn = QPushButton("Open in AnyQATS")
         self.evm_tool_btn = QPushButton("Open Extreme Value Statistics Tool")
         self.rao_tool_btn = QPushButton("Generate RAO from Selected Time Series")
+        self.swan_tool_btn = QPushButton("Open SWANtool")
         tools_layout.addWidget(self.launch_qats_btn)
         tools_layout.addWidget(self.evm_tool_btn)
         tools_layout.addWidget(self.rao_tool_btn)
+        tools_layout.addWidget(self.swan_tool_btn)
         self.controls_layout.addWidget(self.tools_group)
 
         # ---- Plot controls ----
@@ -893,6 +896,7 @@ class TimeSeriesEditorQt(QMainWindow):
         self.launch_qats_btn.clicked.connect(self.launch_qats)
         self.evm_tool_btn.clicked.connect(self.open_evm_tool)
         self.rao_tool_btn.clicked.connect(self.open_rao_tool)
+        self.swan_tool_btn.clicked.connect(self.open_swan_tool)
         self.reselect_orcaflex_btn.clicked.connect(self.reselect_orcaflex_variables)
         self.psd_btn.clicked.connect(lambda: self.plot_selected(mode="psd"))
         self.cycle_range_btn.clicked.connect(lambda: self.plot_selected(mode="cycle"))
@@ -7219,6 +7223,15 @@ class TimeSeriesEditorQt(QMainWindow):
 
         dlg = FatigueDialog(series_entries, self)
         dlg.exec()
+
+    def open_swan_tool(self) -> None:
+        """Launch the SWAN/DNORA post-processing tool."""
+
+        if not hasattr(self, "_swan_tool_window") or self._swan_tool_window is None:
+            self._swan_tool_window = SWANToolDialog()
+        self._swan_tool_window.show()
+        self._swan_tool_window.raise_()
+        self._swan_tool_window.activateWindow()
 
     def open_rao_tool(self) -> None:
         """Launch the RAO dialog for selected time series."""

--- a/anytimes/gui/swan_tool_dialog.py
+++ b/anytimes/gui/swan_tool_dialog.py
@@ -1,0 +1,505 @@
+"""SWAN tool dialog for DNORA post-processing workflows."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import xarray as xr
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg, NavigationToolbar2QT
+from matplotlib.figure import Figure
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QDoubleSpinBox,
+    QFileDialog,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QPlainTextEdit,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
+)
+
+import postprocess_dnora as swan_post
+
+
+@dataclass(frozen=True)
+class Poi:
+    lat: float
+    lon: float
+
+    @property
+    def label(self) -> str:
+        return f"({self.lat:.6f}, {self.lon:.6f})"
+
+
+class SWANToolDialog(QMainWindow):
+    """Interactive SWAN post-processing UI wrapper."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        # Create as proper top-level window (min/max/titlebar) regardless of parent.
+        super().__init__(parent, Qt.Window)
+        self.setWindowTitle("SWANtool")
+        self.resize(1300, 780)
+
+        self._lat_grid: np.ndarray | None = None
+        self._lon_grid: np.ndarray | None = None
+        self._land_mask: np.ndarray | None = None
+        self._depth_grid: np.ndarray | None = None
+        self._preview_nc_path: Path | None = None
+        self._is_syncing_point = False
+
+        central = QWidget(self)
+        self.setCentralWidget(central)
+        root = QVBoxLayout(central)
+        split = QSplitter(Qt.Horizontal)
+        root.addWidget(split)
+
+        left = QWidget()
+        left_layout = QVBoxLayout(left)
+        split.addWidget(left)
+
+        right = QWidget()
+        right_layout = QVBoxLayout(right)
+        split.addWidget(right)
+        split.setSizes([530, 770])
+
+        self._build_folder_group(left_layout)
+        self._build_poi_group(left_layout)
+        self._build_parameter_group(left_layout)
+        self._build_action_row(left_layout)
+        self.log_output = QPlainTextEdit()
+        self.log_output.setReadOnly(True)
+        self.log_output.setPlaceholderText("SWANtool output...")
+        left_layout.addWidget(self.log_output, stretch=1)
+
+        self._build_map(right_layout)
+
+    def _build_folder_group(self, layout: QVBoxLayout) -> None:
+        group = QGroupBox("1) Input folders")
+        vbox = QVBoxLayout(group)
+
+        self.folder_list = QListWidget()
+        self.folder_list.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        vbox.addWidget(self.folder_list)
+
+        btn_row = QHBoxLayout()
+        add_btn = QPushButton("Add folder(s)")
+        remove_btn = QPushButton("Remove selected")
+        btn_row.addWidget(add_btn)
+        btn_row.addWidget(remove_btn)
+        vbox.addLayout(btn_row)
+
+        add_btn.clicked.connect(self._add_folders)
+        remove_btn.clicked.connect(self._remove_selected_folders)
+
+        layout.addWidget(group)
+
+    def _build_poi_group(self, layout: QVBoxLayout) -> None:
+        group = QGroupBox("2) Points of interest (POI)")
+        vbox = QVBoxLayout(group)
+
+        form = QFormLayout()
+        self.poi_lat = QLineEdit()
+        self.poi_lon = QLineEdit()
+        self.poi_lat.setPlaceholderText("e.g. 65.010180")
+        self.poi_lon.setPlaceholderText("e.g. 11.746670")
+        form.addRow("Latitude", self.poi_lat)
+        form.addRow("Longitude", self.poi_lon)
+        vbox.addLayout(form)
+
+        row = QHBoxLayout()
+        add_btn = QPushButton("Add POI")
+        del_btn = QPushButton("Delete selected POI")
+        row.addWidget(add_btn)
+        row.addWidget(del_btn)
+        vbox.addLayout(row)
+
+        self.poi_list = QListWidget()
+        self.poi_list.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        vbox.addWidget(self.poi_list)
+
+        self.poi_lat.textChanged.connect(self._on_manual_point_changed)
+        self.poi_lon.textChanged.connect(self._on_manual_point_changed)
+        add_btn.clicked.connect(self._add_poi)
+        del_btn.clicked.connect(self._delete_poi)
+        self.poi_list.itemSelectionChanged.connect(self._refresh_map)
+
+        layout.addWidget(group)
+
+    def _build_parameter_group(self, layout: QVBoxLayout) -> None:
+        group = QGroupBox("3) Parameters")
+        form = QFormLayout(group)
+
+        self.split_report_cb = QCheckBox("Split report files")
+        self.split_report_cb.setChecked(True)
+        form.addRow(self.split_report_cb)
+
+        self.arrow_resolution = QDoubleSpinBox()
+        self.arrow_resolution.setDecimals(0)
+        self.arrow_resolution.setRange(1, 10000)
+        self.arrow_resolution.setValue(100)
+        form.addRow("Arrow resolution", self.arrow_resolution)
+
+        self.theta_step = QDoubleSpinBox()
+        self.theta_step.setRange(0.1, 360)
+        self.theta_step.setValue(5.0)
+        form.addRow("SPEC_DIR_THETA_STEP_DEG", self.theta_step)
+
+        self.spreading_s = QDoubleSpinBox()
+        self.spreading_s.setRange(0.1, 1000)
+        self.spreading_s.setValue(5.0)
+        form.addRow("SPEC_DIR_SPREADING_S", self.spreading_s)
+
+        layout.addWidget(group)
+
+    def _build_action_row(self, layout: QVBoxLayout) -> None:
+        row = QHBoxLayout()
+        self.run_btn = QPushButton("Run postprocessing (open plots)")
+        self.save_btn = QPushButton("Save output")
+        row.addWidget(self.run_btn)
+        row.addWidget(self.save_btn)
+        self.run_btn.clicked.connect(lambda: self._run(save_output=False))
+        self.save_btn.clicked.connect(lambda: self._run(save_output=True))
+        layout.addLayout(row)
+
+    def _build_map(self, layout: QVBoxLayout) -> None:
+        group = QGroupBox("Map preview from selected .nc region")
+        vbox = QVBoxLayout(group)
+        self.map_info = QLabel("Add/select input folders to load a .nc region preview.")
+        vbox.addWidget(self.map_info)
+
+        self.map_fig = Figure(figsize=(7, 6), facecolor="white")
+        self.map_canvas = FigureCanvasQTAgg(self.map_fig)
+        self.map_canvas.setStyleSheet("background: white;")
+        self.map_toolbar = NavigationToolbar2QT(self.map_canvas, self)
+        self.map_canvas.mpl_connect("button_press_event", self._on_map_clicked)
+        vbox.addWidget(self.map_toolbar)
+        vbox.addWidget(self.map_canvas)
+        layout.addWidget(group)
+
+    def _add_folders(self) -> None:
+        while True:
+            chosen = QFileDialog.getExistingDirectory(self, "Select SWAN result folder")
+            if not chosen:
+                break
+            if not any(self.folder_list.item(i).text() == chosen for i in range(self.folder_list.count())):
+                self.folder_list.addItem(chosen)
+                self._log(f"Added folder: {chosen}")
+            else:
+                self._log(f"Folder already added: {chosen}")
+            again = QMessageBox.question(
+                self,
+                "Add another?",
+                "Add another folder?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if again != QMessageBox.Yes:
+                break
+        self._load_region_preview()
+
+    def _remove_selected_folders(self) -> None:
+        for item in self.folder_list.selectedItems():
+            self._log(f"Removed folder: {item.text()}")
+            self.folder_list.takeItem(self.folder_list.row(item))
+        self._load_region_preview()
+
+    def _add_poi(self) -> None:
+        poi = self._current_manual_poi()
+        if poi is None:
+            QMessageBox.warning(self, "Invalid POI", "Please provide valid numeric latitude and longitude.")
+            return
+        self.poi_list.addItem(QListWidgetItem(poi.label))
+        self._log(f"Added POI: {poi.label}")
+        self._log_current_pois()
+        self._refresh_map()
+
+    def _delete_poi(self) -> None:
+        selected = self.poi_list.selectedItems()
+        if not selected:
+            return
+        for item in selected:
+            self._log(f"Deleted POI: {item.text()}")
+            self.poi_list.takeItem(self.poi_list.row(item))
+        self._log_current_pois()
+        self._refresh_map()
+
+    def _on_manual_point_changed(self) -> None:
+        if self._is_syncing_point:
+            return
+        self._refresh_map()
+
+    def _on_map_clicked(self, event) -> None:
+        if event.xdata is None or event.ydata is None:
+            return
+        self._is_syncing_point = True
+        try:
+            self.poi_lat.setText(f"{event.ydata:.6f}")
+            self.poi_lon.setText(f"{event.xdata:.6f}")
+        finally:
+            self._is_syncing_point = False
+        self._refresh_map()
+
+    def _current_manual_poi(self) -> Poi | None:
+        try:
+            lat = float(self.poi_lat.text().strip())
+            lon = float(self.poi_lon.text().strip())
+        except ValueError:
+            return None
+        return Poi(lat=lat, lon=lon)
+
+    def _poi_values(self) -> list[Poi]:
+        values: list[Poi] = []
+        for i in range(self.poi_list.count()):
+            txt = self.poi_list.item(i).text().strip().strip("()")
+            lat_s, lon_s = [x.strip() for x in txt.split(",", maxsplit=1)]
+            values.append(Poi(lat=float(lat_s), lon=float(lon_s)))
+        return values
+
+    def _folder_paths(self) -> list[Path]:
+        return [Path(self.folder_list.item(i).text()) for i in range(self.folder_list.count())]
+
+    def _load_region_preview(self) -> None:
+        self._lat_grid = None
+        self._lon_grid = None
+        self._land_mask = None
+        self._depth_grid = None
+        self._preview_nc_path = None
+
+        for folder in self._folder_paths():
+            try:
+                nc = swan_post.autodetect_file(folder, ".nc", None)
+                lat, lon, land_mask, depth_grid = self._read_preview_data_from_nc(nc)
+                if lat is None or lon is None:
+                    continue
+                self._lat_grid = lat
+                self._lon_grid = lon
+                self._land_mask = land_mask
+                self._depth_grid = depth_grid
+                self._preview_nc_path = nc
+                self.map_info.setText(f"Preview from: {nc}")
+                self._log(f"Map preview source: {nc}")
+                break
+            except Exception as exc:
+                self._log(f"Preview skip for {folder}: {exc}")
+
+        if self._preview_nc_path is None:
+            self.map_info.setText("No valid .nc file found for region preview.")
+        self._refresh_map()
+
+    def _read_preview_data_from_nc(
+        self, nc_path: Path
+    ) -> tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None, np.ndarray | None]:
+        with xr.open_dataset(nc_path) as ds:
+            lat = self._pick_coord(ds, ("lat", "latitude", "LAT", "nav_lat", "y"))
+            lon = self._pick_coord(ds, ("lon", "longitude", "LON", "nav_lon", "x"))
+            if lat is None or lon is None:
+                return None, None, None, None
+            lat_vals = np.asarray(lat.values)
+            lon_vals = np.asarray(lon.values)
+
+            if lat_vals.ndim == 1 and lon_vals.ndim == 1:
+                lon_grid, lat_grid = np.meshgrid(lon_vals, lat_vals)
+            elif lat_vals.shape == lon_vals.shape:
+                lat_grid, lon_grid = lat_vals, lon_vals
+            else:
+                return None, None, None, None
+
+            depth_grid = self._extract_depth_grid(ds, lat_grid.shape)
+            land_mask = self._extract_land_mask(ds, lat_grid.shape, depth_grid=depth_grid)
+            return lat_grid, lon_grid, land_mask, depth_grid
+
+    def _extract_depth_grid(self, ds: xr.Dataset, target_shape: tuple[int, ...]) -> np.ndarray | None:
+        depth_candidates = ("depth", "DEPTH", "bathymetry", "h", "topo")
+        for name in depth_candidates:
+            if name in ds:
+                arr = self._to_2d_array(np.asarray(ds[name].values))
+                if arr is not None and arr.shape == target_shape:
+                    return arr.astype(float)
+        return None
+
+    def _extract_land_mask(
+        self,
+        ds: xr.Dataset,
+        target_shape: tuple[int, ...],
+        depth_grid: np.ndarray | None = None,
+    ) -> np.ndarray | None:
+        mask_candidates = (
+            "land_mask",
+            "mask",
+            "LANDMASK",
+            "wetmask",
+            "wetdry_mask",
+            "sea_mask",
+        )
+        for name in mask_candidates:
+            if name in ds:
+                arr = self._to_2d_array(np.asarray(ds[name].values))
+                if arr is not None and arr.shape == target_shape:
+                    # Normalize to boolean land mask when possible.
+                    return arr > 0.5
+
+        if depth_grid is not None and depth_grid.shape == target_shape:
+            return ~np.isfinite(depth_grid) | (depth_grid <= 0)
+
+        # Fallback: infer land from NaN coverage in Hs.
+        hs = self._pick_data_var(ds, getattr(swan_post, "HS_CANDIDATES", ("hs", "swh", "Hsig")))
+        if hs is not None:
+            arr = np.asarray(hs.values)
+            if "time" in hs.dims and arr.ndim >= 3:
+                arr2d = self._to_2d_array(arr[0])
+            else:
+                arr2d = self._to_2d_array(arr)
+            if arr2d is not None and arr2d.shape == target_shape:
+                return ~np.isfinite(arr2d)
+
+        return None
+
+    def _to_2d_array(self, arr: np.ndarray) -> np.ndarray | None:
+        if arr.ndim == 2:
+            return arr
+        if arr.ndim == 3:
+            return arr[0]
+        return None
+
+    def _pick_data_var(self, ds: xr.Dataset, names: Iterable[str]):
+        for name in names:
+            if name in ds:
+                return ds[name]
+        return None
+
+    def _pick_coord(self, ds: xr.Dataset, names: Iterable[str]):
+        for name in names:
+            if name in ds.coords:
+                return ds.coords[name]
+            if name in ds:
+                return ds[name]
+        return None
+
+    def _refresh_map(self) -> None:
+        self.map_fig.clear()
+        ax = self.map_fig.add_subplot(111)
+        ax.set_xlabel("Longitude")
+        ax.set_ylabel("Latitude")
+        ax.grid(True, alpha=0.25)
+        ax.set_facecolor("#f7fbff")
+
+        if self._lat_grid is not None and self._lon_grid is not None:
+            lat = self._lat_grid
+            lon = self._lon_grid
+            depth = self._depth_grid
+
+            if depth is not None and depth.shape == lat.shape:
+                depth_plot = np.ma.masked_invalid(depth)
+                mesh = ax.pcolormesh(
+                    lon,
+                    lat,
+                    depth_plot,
+                    shading="auto",
+                    cmap="viridis",
+                    alpha=0.90,
+                )
+                self.map_fig.colorbar(mesh, ax=ax, label="Depth [m] (positive downward)")
+                if np.nanmin(depth) <= 0 <= np.nanmax(depth):
+                    ax.contour(lon, lat, depth, levels=[0.0], colors="cyan", linewidths=1.2)
+
+            if self._land_mask is not None and self._land_mask.shape == lat.shape:
+                mask = np.ma.masked_where(~self._land_mask, self._land_mask.astype(float))
+                ax.pcolormesh(
+                    lon,
+                    lat,
+                    mask,
+                    shading="auto",
+                    cmap="OrRd",
+                    alpha=0.45,
+                )
+            ax.scatter(lon.ravel(), lat.ravel(), s=0.4, alpha=0.20, color="white", label="Grid")
+            ax.set_xlim(np.nanmin(lon), np.nanmax(lon))
+            ax.set_ylim(np.nanmin(lat), np.nanmax(lat))
+
+        manual = self._current_manual_poi()
+        if manual is not None:
+            ax.scatter([manual.lon], [manual.lat], color="red", s=90, marker="x", label="Manual POI")
+
+        pois = self._poi_values()
+        if pois:
+            ax.scatter([p.lon for p in pois], [p.lat for p in pois], color="orange", s=45, label="POI list")
+
+        handles, labels = ax.get_legend_handles_labels()
+        if handles:
+            ax.legend(loc="best")
+
+        self.map_canvas.draw_idle()
+
+    def _run(self, save_output: bool) -> None:
+        folders = self._folder_paths()
+        if not folders:
+            QMessageBox.warning(self, "No folders", "Please add at least one input folder.")
+            return
+
+        pois = self._poi_values()
+        self._log("Running SWANtool with parameters:")
+        self._log(f"  SPLIT_REPORT_FILES={self.split_report_cb.isChecked()}")
+        self._log(f"  DEFAULT_ARROW_RESOLUTION={int(self.arrow_resolution.value())}")
+        self._log(f"  SPEC_DIR_THETA_STEP_DEG={self.theta_step.value()}")
+        self._log(f"  SPEC_DIR_SPREADING_S={self.spreading_s.value()}")
+        self._log(f"  Save output requested: {save_output}")
+
+        if save_output:
+            QMessageBox.information(
+                self,
+                "Save output",
+                "Save output was requested. The imported postprocessor currently controls actual export behavior.",
+            )
+
+        for folder in folders:
+            try:
+                nc_path = swan_post.autodetect_file(folder, ".nc", None)
+            except Exception as exc:
+                self._log(f"Skipping folder '{folder}': {exc}")
+                continue
+
+            if not pois:
+                self._log(f"Plotting default point for {nc_path.name}")
+                data = swan_post.load_timeseries(nc_path, point_index=None)
+                swan_post.plot_timeseries(data, title=f"SWAN postprocessing — {nc_path.name}")
+                continue
+
+            for poi in pois:
+                idx = self._nearest_point_index(nc_path, poi)
+                self._log(f"Plotting {nc_path.name} at POI {poi.label} (point_index={idx})")
+                data = swan_post.load_timeseries(nc_path, point_index=idx)
+                swan_post.plot_timeseries(data, title=f"SWAN postprocessing — {nc_path.name} @ {poi.label}")
+
+    def _nearest_point_index(self, nc_path: Path, poi: Poi) -> int | None:
+        lat, lon, _, _ = self._read_preview_data_from_nc(nc_path)
+        if lat is None or lon is None:
+            return None
+
+        dist = np.hypot(lat - poi.lat, lon - poi.lon)
+        flat_idx = int(np.nanargmin(dist))
+        return flat_idx
+
+    def _log(self, message: str) -> None:
+        self.log_output.appendPlainText(message)
+
+    def _log_current_pois(self) -> None:
+        pois = self._poi_values()
+        if not pois:
+            self._log("Current POIs: [none]")
+            return
+        self._log("Current POIs:")
+        for i, poi in enumerate(pois, start=1):
+            self._log(f"  {i}. {poi.label}")

--- a/postprocess_dnora.py
+++ b/postprocess_dnora.py
@@ -34,8 +34,8 @@ HS_CANDIDATES = ("hs", "swh", "significant_wave_height", "Hsig")
 TP_CANDIDATES = ("tp", "peak_period", "peak_wave_period", "Tm01")
 WIND_SPEED_CANDIDATES = ("wind_speed", "wspd", "ws", "windspd")
 WIND_DIR_CANDIDATES = ("wind_dir", "wdir", "wd", "winddir")
-WIND_U_CANDIDATES = ("wind_u", "u10", "uwnd", "x_wind")
-WIND_V_CANDIDATES = ("wind_v", "v10", "vwnd", "y_wind")
+WIND_U_CANDIDATES = ("wind_u", "u10", "uwnd", "x_wind", "xwnd")
+WIND_V_CANDIDATES = ("wind_v", "v10", "vwnd", "y_wind", "ywnd")
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
### Motivation
- Provide an interactive SWAN/DNORA post-processing UI inside the timeseries editor and improve compatibility with additional wind variable names from SWAN outputs.

### Description
- Add `anytimes/gui/swan_tool_dialog.py` implementing `SWANToolDialog`, which provides folder selection, POI (points of interest) management, map preview from a discovered `.nc` file, plotting hooks, and run/save actions via the existing `postprocess_dnora` helper.
- Integrate the new tool into the main editor by importing `SWANToolDialog`, adding an "Open SWANtool" button to the Tools panel, wiring the button to `open_swan_tool`, and implementing `open_swan_tool` to show/raise the dialog in `anytimes/gui/editor.py`.
- Extend `postprocess_dnora.py` wind variable candidate lists by adding `"xwnd"` and `"ywnd"` to `WIND_U_CANDIDATES` and `WIND_V_CANDIDATES` to handle more naming variants in input datasets.

### Testing
- Ran the repository test suite with `pytest -q` against the modified code and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef113c6c44832c833311da05a97089)