### PR TITLE
GUI: multi-folder preview + preview layer stacking; CLI flags for split/auto-open reports; run/refactor changes

### DIFF
--- a/anytimes/gui/postprocess_dnora_source.py
+++ b/anytimes/gui/postprocess_dnora_source.py
@@ -896,6 +896,32 @@ def parse_args() -> Inputs:
         default=5.0,
         help="Spreading parameter s for oceanwaves.as_directional (default: 5.0).",
     )
+    parser.add_argument(
+        "--split-report-files",
+        dest="split_report_files",
+        action="store_true",
+        default=None,
+        help="Write split HTML reports (default: current script setting).",
+    )
+    parser.add_argument(
+        "--single-report-file",
+        dest="split_report_files",
+        action="store_false",
+        help="Write a single combined HTML report.",
+    )
+    parser.add_argument(
+        "--auto-open-split-files",
+        dest="auto_open_split_files",
+        action="store_true",
+        default=None,
+        help="Auto-open produced HTML reports in browser (default: current script setting).",
+    )
+    parser.add_argument(
+        "--no-auto-open-split-files",
+        dest="auto_open_split_files",
+        action="store_false",
+        help="Do not auto-open produced HTML reports.",
+    )
 
     args = parser.parse_args()
     directories = tuple(Path(d).expanduser().resolve() for d in args.directory)
@@ -944,6 +970,11 @@ def parse_args() -> Inputs:
             spec_file = None
 
     point_coords = _resolve_point_coordinates(args.point_lat, args.point_lon)
+
+    if args.split_report_files is not None:
+        globals()["SPLIT_REPORT_FILES"] = bool(args.split_report_files)
+    if args.auto_open_split_files is not None:
+        globals()["AUTO_OPEN_SPLIT_FILES"] = bool(args.auto_open_split_files)
 
     return Inputs(
         directories=directories,
@@ -5562,7 +5593,7 @@ def generate_metocean_report(
             print(f"Open manually: http://127.0.0.1:{port}/{out_files[0].name}")
 
 def main() -> None:
-    use_code_config = USE_CODE_CONFIG or len(sys.argv) == 1
+    use_code_config = USE_CODE_CONFIG and len(sys.argv) == 1
     inputs = _build_inputs_from_code_config() if use_code_config else parse_args()
 
     point_coords = _normalize_point_coords(inputs.point_coord)

--- a/anytimes/gui/swan_tool_dialog.py
+++ b/anytimes/gui/swan_tool_dialog.py
@@ -35,7 +35,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-import postprocess_dnora as swan_post
+from anytimes.gui import postprocess_dnora_source as swan_post
 
 
 @dataclass(frozen=True)
@@ -48,6 +48,16 @@ class Poi:
         return f"({self.lat:.6f}, {self.lon:.6f})"
 
 
+@dataclass(frozen=True)
+class PreviewLayer:
+    source_nc: Path
+    lat: np.ndarray
+    lon: np.ndarray
+    depth: np.ndarray | None
+    land_mask: np.ndarray | None
+    resolution_score: float
+
+
 class SWANToolDialog(QMainWindow):
     """Interactive SWAN post-processing UI wrapper."""
 
@@ -57,10 +67,7 @@ class SWANToolDialog(QMainWindow):
         self.setWindowTitle("SWANtool")
         self.resize(1300, 780)
 
-        self._lat_grid: np.ndarray | None = None
-        self._lon_grid: np.ndarray | None = None
-        self._land_mask: np.ndarray | None = None
-        self._depth_grid: np.ndarray | None = None
+        self._preview_layers: list[PreviewLayer] = []
         self._preview_nc_path: Path | None = None
         self._is_syncing_point = False
 
@@ -297,39 +304,83 @@ class SWANToolDialog(QMainWindow):
         return [Path(self.folder_list.item(i).text()) for i in range(self.folder_list.count())]
 
     def _load_region_preview(self) -> None:
-        self._lat_grid = None
-        self._lon_grid = None
-        self._land_mask = None
-        self._depth_grid = None
+        self._preview_layers = []
         self._preview_nc_path = None
 
+        loaded_layers: list[PreviewLayer] = []
         for folder in self._folder_paths():
             try:
-                nc = swan_post.autodetect_file(folder, ".nc", None)
+                nc = self._autodetect_preview_nc(folder)
                 lat, lon, land_mask, depth_grid = self._read_preview_data_from_nc(nc)
                 if lat is None or lon is None:
                     continue
-                self._lat_grid = lat
-                self._lon_grid = lon
-                self._land_mask = land_mask
-                self._depth_grid = depth_grid
-                self._preview_nc_path = nc
-                self.map_info.setText(f"Preview from: {nc}")
-                self._log(f"Map preview source: {nc}")
-                break
+                loaded_layers.append(
+                    PreviewLayer(
+                        source_nc=nc,
+                        lat=lat,
+                        lon=lon,
+                        depth=depth_grid,
+                        land_mask=land_mask,
+                        resolution_score=self._grid_resolution_score(lat, lon),
+                    )
+                )
+                self._log(f"Map preview source added: {nc}")
             except Exception as exc:
                 self._log(f"Preview skip for {folder}: {exc}")
 
-        if self._preview_nc_path is None:
+        if loaded_layers:
+            # Draw coarse first and fine last => finest takes precedence visually.
+            self._preview_layers = sorted(loaded_layers, key=lambda layer: layer.resolution_score, reverse=True)
+            self._preview_nc_path = self._preview_layers[-1].source_nc
+            self.map_info.setText(
+                f"Preview from {len(self._preview_layers)} folder(s); finest overlay: {self._preview_nc_path.name}"
+            )
+        else:
             self.map_info.setText("No valid .nc file found for region preview.")
+
         self._refresh_map()
+
+    def _grid_resolution_score(self, lat: np.ndarray, lon: np.ndarray) -> float:
+        def _axis_spacing(arr: np.ndarray) -> float:
+            vals = np.asarray(arr, dtype=float).ravel()
+            vals = vals[np.isfinite(vals)]
+            if vals.size < 2:
+                return float("inf")
+            diffs = np.abs(np.diff(np.unique(vals)))
+            diffs = diffs[diffs > 0]
+            if diffs.size == 0:
+                return float("inf")
+            return float(np.nanmedian(diffs))
+
+        if lat.ndim == 2 and lon.ndim == 2:
+            dlat = _axis_spacing(lat[:, 0])
+            dlon = _axis_spacing(lon[0, :])
+        else:
+            dlat = _axis_spacing(lat)
+            dlon = _axis_spacing(lon)
+        return dlat * dlon
+
+    def _autodetect_preview_nc(self, folder: Path) -> Path:
+        candidates = [
+            p for p in folder.iterdir()
+            if p.is_file() and p.suffix.lower() == ".nc" and "spec" not in p.name.lower()
+        ]
+        if not candidates:
+            raise FileNotFoundError(f"No non-spec .nc file found in {folder}")
+        return sorted(candidates, key=lambda p: (-p.stat().st_size, p.name.lower()))[0]
 
     def _read_preview_data_from_nc(
         self, nc_path: Path
     ) -> tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None, np.ndarray | None]:
+        # Local import keeps this function robust in bundled/runtime environments
+        # where module globals may not be initialized as expected.
+        import xarray as xr
+
         with xr.open_dataset(nc_path) as ds:
             lat = self._pick_coord(ds, ("lat", "latitude", "LAT", "nav_lat", "y"))
             lon = self._pick_coord(ds, ("lon", "longitude", "LON", "nav_lon", "x"))
+            if lat is None or lon is None:
+                lat, lon = self._fallback_lat_lon_from_dims(ds)
             if lat is None or lon is None:
                 return None, None, None, None
             lat_vals = np.asarray(lat.values)
@@ -346,6 +397,15 @@ class SWANToolDialog(QMainWindow):
             land_mask = self._extract_land_mask(ds, lat_grid.shape, depth_grid=depth_grid)
             return lat_grid, lon_grid, land_mask, depth_grid
 
+    def _fallback_lat_lon_from_dims(self, ds: xr.Dataset):
+        lat_dim = next((d for d in ("lat", "latitude", "y") if d in ds.dims), None)
+        lon_dim = next((d for d in ("lon", "longitude", "x") if d in ds.dims), None)
+        if lat_dim is None or lon_dim is None:
+            return None, None
+        if lat_dim not in ds.coords or lon_dim not in ds.coords:
+            return None, None
+        return ds.coords[lat_dim], ds.coords[lon_dim]
+
     def _extract_depth_grid(self, ds: xr.Dataset, target_shape: tuple[int, ...]) -> np.ndarray | None:
         depth_candidates = ("depth", "DEPTH", "bathymetry", "h", "topo")
         for name in depth_candidates:
@@ -361,6 +421,10 @@ class SWANToolDialog(QMainWindow):
         target_shape: tuple[int, ...],
         depth_grid: np.ndarray | None = None,
     ) -> np.ndarray | None:
+        # Preferred behavior: derive land mask from depth (0 at WL, positive downward).
+        if depth_grid is not None and depth_grid.shape == target_shape:
+            return ~np.isfinite(depth_grid) | (depth_grid <= 0.0)
+
         mask_candidates = (
             "land_mask",
             "mask",
@@ -375,9 +439,6 @@ class SWANToolDialog(QMainWindow):
                 if arr is not None and arr.shape == target_shape:
                     # Normalize to boolean land mask when possible.
                     return arr > 0.5
-
-        if depth_grid is not None and depth_grid.shape == target_shape:
-            return ~np.isfinite(depth_grid) | (depth_grid <= 0)
 
         # Fallback: infer land from NaN coverage in Hs.
         hs = self._pick_data_var(ds, getattr(swan_post, "HS_CANDIDATES", ("hs", "swh", "Hsig")))
@@ -421,38 +482,78 @@ class SWANToolDialog(QMainWindow):
         ax.grid(True, alpha=0.25)
         ax.set_facecolor("#f7fbff")
 
-        if self._lat_grid is not None and self._lon_grid is not None:
-            lat = self._lat_grid
-            lon = self._lon_grid
-            depth = self._depth_grid
+        if self._preview_layers:
+            depth_vals: list[np.ndarray] = []
+            all_lon: list[np.ndarray] = []
+            all_lat: list[np.ndarray] = []
+            for layer in self._preview_layers:
+                all_lon.append(layer.lon.ravel())
+                all_lat.append(layer.lat.ravel())
+                if layer.depth is not None:
+                    depth_vals.append(np.asarray(layer.depth, dtype=float).ravel())
 
-            if depth is not None and depth.shape == lat.shape:
-                depth_plot = np.ma.masked_invalid(depth)
-                mesh = ax.pcolormesh(
-                    lon,
-                    lat,
-                    depth_plot,
-                    shading="auto",
-                    cmap="viridis",
-                    alpha=0.90,
-                )
+            if depth_vals:
+                depth_concat = np.concatenate(depth_vals)
+                depth_concat = depth_concat[np.isfinite(depth_concat)]
+                depth_min = float(np.nanmin(depth_concat))
+                depth_max = float(np.nanmax(depth_concat))
+            else:
+                depth_min, depth_max = 0.0, 1.0
+
+            mesh = None
+            for layer in self._preview_layers:
+                lat = layer.lat
+                lon = layer.lon
+                depth = layer.depth
+
+                if depth is not None and depth.shape == lat.shape:
+                    depth_plot = np.ma.masked_invalid(depth)
+                    mesh = ax.pcolormesh(
+                        lon,
+                        lat,
+                        depth_plot,
+                        shading="auto",
+                        cmap="viridis",
+                        vmin=depth_min,
+                        vmax=depth_max,
+                        alpha=0.90,
+                    )
+                    if np.nanmin(depth) <= 0 <= np.nanmax(depth):
+                        ax.contour(lon, lat, depth, levels=[0.0], colors="cyan", linewidths=1.0)
+
+                if layer.land_mask is not None and layer.land_mask.shape == lat.shape:
+                    land_mask = layer.land_mask.astype(float)
+                    mask = np.ma.masked_where(land_mask < 0.5, land_mask)
+                    ax.pcolormesh(
+                        lon,
+                        lat,
+                        mask,
+                        shading="auto",
+                        cmap="OrRd",
+                        vmin=0.0,
+                        vmax=1.0,
+                        alpha=0.35,
+                    )
+                    ax.contour(
+                        lon,
+                        lat,
+                        land_mask,
+                        levels=[0.5],
+                        colors="black",
+                        linewidths=1.0,
+                        alpha=0.95,
+                    )
+
+            if mesh is not None:
                 self.map_fig.colorbar(mesh, ax=ax, label="Depth [m] (positive downward)")
-                if np.nanmin(depth) <= 0 <= np.nanmax(depth):
-                    ax.contour(lon, lat, depth, levels=[0.0], colors="cyan", linewidths=1.2)
 
-            if self._land_mask is not None and self._land_mask.shape == lat.shape:
-                mask = np.ma.masked_where(~self._land_mask, self._land_mask.astype(float))
-                ax.pcolormesh(
-                    lon,
-                    lat,
-                    mask,
-                    shading="auto",
-                    cmap="OrRd",
-                    alpha=0.45,
-                )
-            ax.scatter(lon.ravel(), lat.ravel(), s=0.4, alpha=0.20, color="white", label="Grid")
-            ax.set_xlim(np.nanmin(lon), np.nanmax(lon))
-            ax.set_ylim(np.nanmin(lat), np.nanmax(lat))
+            lon_concat = np.concatenate(all_lon)
+            lat_concat = np.concatenate(all_lat)
+            lon_concat = lon_concat[np.isfinite(lon_concat)]
+            lat_concat = lat_concat[np.isfinite(lat_concat)]
+            if lon_concat.size and lat_concat.size:
+                ax.set_xlim(np.nanmin(lon_concat), np.nanmax(lon_concat))
+                ax.set_ylim(np.nanmin(lat_concat), np.nanmax(lat_concat))
 
         manual = self._current_manual_poi()
         if manual is not None:
@@ -475,6 +576,18 @@ class SWANToolDialog(QMainWindow):
             return
 
         pois = self._poi_values()
+        if not pois:
+            manual = self._current_manual_poi()
+            if manual is not None:
+                pois = [manual]
+                self._log(f"Using manual POI without adding to list: {manual.label}")
+            else:
+                QMessageBox.warning(
+                    self,
+                    "No POI",
+                    "Please add at least one valid POI (or enter a valid manual latitude/longitude) before running.",
+                )
+                return
         self._log("Running SWANtool with parameters:")
         self._log(f"  SPLIT_REPORT_FILES={self.split_report_cb.isChecked()}")
         self._log(f"  DEFAULT_ARROW_RESOLUTION={int(self.arrow_resolution.value())}")
@@ -482,49 +595,39 @@ class SWANToolDialog(QMainWindow):
         self._log(f"  SPEC_DIR_SPREADING_S={self.spreading_s.value()}")
         self._log(f"  Save output requested: {save_output}")
 
-        if save_output:
-            QMessageBox.information(
-                self,
-                "Save output",
-                "Save output was requested. The imported postprocessor currently controls actual export behavior.",
-            )
-
-        for folder in folders:
-            try:
-                nc_path = swan_post.autodetect_file(folder, ".nc", None)
-            except Exception as exc:
-                self._log(f"Skipping folder '{folder}': {exc}")
-                continue
-
-            if not pois:
-                started_at = self._now_epoch()
-                self._log(f"Running source postprocessor for default point: {nc_path.name}")
-                self._run_source_postprocessor(folder, point_index=None)
-                self._open_new_html_outputs(folder, started_at)
-                continue
-
-            for poi in pois:
-                started_at = self._now_epoch()
-                idx = self._nearest_point_index(nc_path, poi)
-                self._log(f"Running source postprocessor for {nc_path.name} at POI {poi.label} (point_index={idx})")
-                self._run_source_postprocessor(folder, point_index=idx)
+        started_at = self._now_epoch()
+        self._run_source_postprocessor(
+            folders=folders,
+            pois=pois,
+            save_output=save_output,
+        )
+        if not save_output:
+            for folder in folders:
                 self._open_new_html_outputs(folder, started_at)
 
-    def _run_source_postprocessor(self, folder: Path, point_index: int | None) -> None:
+    def _run_source_postprocessor(self, folders: list[Path], pois: list[Poi], save_output: bool) -> None:
         script_path = Path(self.script_path_edit.text().strip() or str(Path(swan_post.__file__).resolve())).resolve()
         if not script_path.exists():
             self._log(f"Postprocessor script not found: {script_path}")
             return
-        cmd = [sys.executable, str(script_path), str(folder)]
-        if point_index is not None:
-            cmd += ["--point-index", str(int(point_index))]
+
+        cmd = [sys.executable, str(script_path), *(str(folder) for folder in folders)]
+        cmd += ["--wind-arrow-resolution", str(int(self.arrow_resolution.value()))]
+        cmd += ["--spec-dir-theta-step-deg", str(self.theta_step.value())]
+        cmd += ["--spec-dir-spreading-s", str(self.spreading_s.value())]
+        cmd += ["--split-report-files" if self.split_report_cb.isChecked() else "--single-report-file"]
+        cmd += ["--no-auto-open-split-files" if save_output else "--auto-open-split-files"]
+        for poi in pois:
+            cmd += ["--point-lat", f"{poi.lat:.6f}", "--point-lon", f"{poi.lon:.6f}"]
+        self._log(f"Executing: {' '.join(cmd)}")
         try:
             env = dict(**os.environ)
-            # Avoid opening legacy matplotlib figures when script supports HTML report output.
             env.setdefault("MPLBACKEND", "Agg")
-            subprocess.run(cmd, check=True, cwd=str(folder), env=env)
+            subprocess.run(cmd, check=True, cwd=str(folders[0]), env=env)
+            mode = "saved (no auto-open)" if save_output else "generated and auto-opened"
+            self._log(f"Postprocessor completed; outputs {mode}.")
         except subprocess.CalledProcessError as exc:
-            self._log(f"Postprocessor failed for {folder}: {exc}")
+            self._log(f"Postprocessor failed: {exc}")
 
     def _open_new_html_outputs(self, folder: Path, started_at: float) -> None:
         html_files = sorted(
@@ -541,40 +644,6 @@ class SWANToolDialog(QMainWindow):
     def _now_epoch(self) -> float:
         import time
         return time.time()
-
-    def _nearest_point_index(self, nc_path: Path, poi: Poi) -> int | None:
-        # Build point index using the same stacked non-time dimension ordering
-        # that postprocess_dnora._to_series() uses internally.
-        with xr.open_dataset(nc_path) as ds:
-            hs = None
-            for name in getattr(swan_post, "HS_CANDIDATES", ("hs", "swh", "Hsig")):
-                if name in ds:
-                    hs = ds[name]
-                    break
-            if hs is None or "time" not in hs.dims:
-                return None
-
-            non_time_dims = [d for d in hs.dims if d != "time"]
-            if not non_time_dims:
-                return None
-
-            lat_da = self._pick_coord(ds, ("lat", "latitude", "LAT", "nav_lat", "y"))
-            lon_da = self._pick_coord(ds, ("lon", "longitude", "LON", "nav_lon", "x"))
-            if lat_da is None or lon_da is None:
-                return None
-
-            # Align coordinate arrays to the same non-time dimensions as hs.
-            template = hs.isel(time=0)
-            lat_b, lon_b, _ = xr.broadcast(lat_da, lon_da, template)
-            if any(dim not in lat_b.dims for dim in non_time_dims):
-                return None
-
-            lat_s = lat_b.transpose(*non_time_dims).stack(point=non_time_dims)
-            lon_s = lon_b.transpose(*non_time_dims).stack(point=non_time_dims)
-            dist = np.hypot(np.asarray(lat_s.values, dtype=float) - poi.lat, np.asarray(lon_s.values, dtype=float) - poi.lon)
-            if dist.size == 0 or not np.any(np.isfinite(dist)):
-                return None
-            return int(np.nanargmin(dist))
 
     def _log(self, message: str) -> None:
         self.log_output.appendPlainText(message)


### PR DESCRIPTION
### Motivation

- Provide richer map previews from multiple input folders by stacking coverage from multiple run outputs and picking the finest-resolution overlay. 
- Give users explicit CLI control over writing split HTML report files and whether to auto-open them, and make script/config selection clearer. 
- Simplify and centralize how the GUI invokes the postprocessor so it can run across multiple folders and propagate the new CLI options.

### Description

- Added two new CLI options to `postprocess_dnora_source.py`: `--split-report-files/--single-report-file` and `--auto-open-split-files/--no-auto-open-split-files`, and apply them to the script globals when provided. 
- Changed code-config selection logic from `USE_CODE_CONFIG or len(sys.argv) == 1` to `USE_CODE_CONFIG and len(sys.argv) == 1` to avoid unintentionally using code config when CLI args are present. 
- Refactored `swan_tool_dialog.py` to import the postprocessor from `anytimes.gui.postprocess_dnora_source`, introduced a `PreviewLayer` dataclass, and replaced the single-source preview with stacked preview layers chosen by a computed resolution score so finer grids overlay coarser ones. 
- Added robust preview data handling including `_autodetect_preview_nc`, `_fallback_lat_lon_from_dims`, and `_grid_resolution_score`, improved depth and land-mask extraction (prefer deriving mask from depth), and multi-layer plotting with consistent color scaling and zero-depth contouring. 
- Updated run flow so `SWANToolDialog` can run the postprocessor once for multiple folders, pass per-run flags (wind arrow resolution and spectral params, split/auto-open options, and one or more POIs) and log results; removed the old `nearest_point_index` logic and per-folder subprocess invocation. 

### Testing

- Ran the repository unit test suite with `pytest -q`, and the tests completed successfully. 
- Executed a CLI smoke check with `python -m anytimes.gui.postprocess_dnora_source --help` to validate new options parse correctly and it exited with success. 
- Performed headless GUI preview loading smoke tests using representative NetCDF fixtures to verify stacked preview construction and rendering, and those smoke tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef28213e10832c9f9db661d09e94b6)