### PR TITLE
Fix unresolved references in Bokeh plotting branch of editor.py

### DIFF
--- a/anytimes/gui/editor.py
+++ b/anytimes/gui/editor.py
@@ -5336,55 +5336,6 @@ class TimeSeriesEditorQt(QMainWindow):
                                     )
                     region_curve = next(
                         (
-                            curve
-                            for curve in curves
-                            if curve.get("region_mask") is not None
-                            and np.asarray(curve.get("region_mask")).size == len(curve["t"])
-                        ),
-                        None,
-                    )
-                    if region_curve is not None:
-                        y_vals = np.concatenate([np.asarray(curve["y"]) for curve in curves]) if curves else np.array([])
-                        if y_vals.size:
-                            y_low = float(np.nanmin(y_vals))
-                            y_high = float(np.nanmax(y_vals))
-                            if np.isfinite(y_low) and np.isfinite(y_high):
-                                if abs(y_high - y_low) < 1e-12:
-                                    y_high = y_low + 1.0
-                                for seg_start, seg_end in self._mask_segments(
-                                    np.asarray(region_curve["t"]),
-                                    np.asarray(region_curve["region_mask"], dtype=bool),
-                                ):
-                                    fig.add_trace(
-                                        go.Scatter(
-                                            x=[seg_start, seg_start, seg_end, seg_end, seg_start],
-                                            y=[y_low, y_high, y_high, y_low, y_low],
-                                            mode="lines",
-                                            line=dict(width=0),
-                                            fill="toself",
-                                            fillcolor="rgba(255,215,0,0.25)",
-                                            hoverinfo="skip",
-                                            showlegend=False,
-                                        ),
-                                        row=r,
-                                        col=c,
-                                    )
-                                mid = region_curve.get("region_midpoint")
-                                if mid is not None:
-                                    fig.add_trace(
-                                        go.Scatter(
-                                            x=[mid[0]],
-                                            y=[mid[1]],
-                                            mode="markers",
-                                            marker=dict(color="gold", size=8),
-                                            opacity=0.8,
-                                            showlegend=False,
-                                        ),
-                                        row=r,
-                                        col=c,
-                                    )
-                    region_curve = next(
-                        (
                             c
                             for c in curves
                             if c.get("region_mask") is not None


### PR DESCRIPTION
### Motivation
- The Bokeh plotting path contained an accidentally duplicated Plotly trace block that referenced `go`, `r`, and `c`, which are only defined in the Plotly branch, causing unresolved-reference errors. 
- Remove the out-of-scope Plotly code so the Bokeh branch uses only Bokeh-native primitives and variables in scope.

### Description
- Removed the duplicated Plotly `fig.add_trace(go.Scatter(...))` block from the Bokeh branch in `anytimes/gui/editor.py` so the Bokeh path no longer references `go`, `r`, or `c` out of scope. 
- Left the Bokeh-native region rendering (`p.quad` for region areas and optional `p.scatter` midpoint marker) intact as the single implementation in the Bokeh branch. 
- The change is a focused cleanup (approximately 49 lines removed) and does not modify the Plotly branch behavior.

### Testing
- Ran `python -m py_compile anytimes/gui/editor.py` and the file compiled successfully. 
- Static/quick checks show the Bokeh branch no longer references Plotly symbols out of scope and the module import/compile step passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0870c96f4832c9ee0a52b3a0b22e5)