### PR TITLE
Fix Bokeh datetime x-axis detection in time-series plotting

### DIFF
--- a/anytimes/gui/editor.py
+++ b/anytimes/gui/editor.py
@@ -5274,12 +5274,14 @@ class TimeSeriesEditorQt(QMainWindow):
                 for _, data in items:
                     lbl = data["label"]
                     curves = data["curves"]
+                    x_axis_type = self._bokeh_x_axis_type_from_traces(curves)
                     p = figure(
                         width=450,
                         height=300,
                         title=lbl,
                         x_axis_label=self._x_axis_label(),
                         y_axis_label=self.yaxis_label.text() or "Value",
+                        x_axis_type=x_axis_type,
                         tools="pan,wheel_zoom,box_zoom,reset,save",
                         sizing_mode="stretch_both",
                     )
@@ -6072,6 +6074,7 @@ class TimeSeriesEditorQt(QMainWindow):
                 title=title,
                 x_axis_label=self._x_axis_label(),
                 y_axis_label=y_label,
+                x_axis_type=self._bokeh_x_axis_type_from_traces(traces),
                 tools="pan,wheel_zoom,box_zoom,reset,save",
                 sizing_mode="stretch_both",
             )
@@ -6640,6 +6643,19 @@ class TimeSeriesEditorQt(QMainWindow):
         if converted.notna().any():
             return converted
         return time_values
+
+    @staticmethod
+    def _bokeh_x_axis_type_from_traces(traces) -> str:
+        for trace in traces or []:
+            t_vals = np.asarray(trace.get("t", []))
+            if t_vals.size == 0:
+                continue
+            if np.issubdtype(t_vals.dtype, np.datetime64):
+                return "datetime"
+            first_valid = next((val for val in t_vals if pd.notna(val)), None)
+            if isinstance(first_valid, (pd.Timestamp, datetime.datetime, np.datetime64)):
+                return "datetime"
+        return "linear"
 
     def plot_mean(self):
         self.rebuild_var_lookup()

--- a/tests/test_merge_selected.py
+++ b/tests/test_merge_selected.py
@@ -657,3 +657,15 @@ def test_export_selected_to_csv_keeps_per_series_time_for_different_timebases(
     assert np.allclose(df["VarA_t"].to_numpy(), np.array([0.0, 1.0, 2.0]))
     assert np.allclose(df["VarB_t"].to_numpy(), np.array([0.0, 1.5, 3.0]))
     assert not message_spy["warn"]
+
+
+def test_bokeh_axis_type_detects_datetime_traces():
+    traces = [{"t": pd.date_range("2024-01-01", periods=3, freq="h"), "y": [1.0, 2.0, 3.0]}]
+    axis_type = TimeSeriesEditorQt._bokeh_x_axis_type_from_traces(traces)
+    assert axis_type == "datetime"
+
+
+def test_bokeh_axis_type_defaults_to_linear_for_numeric_traces():
+    traces = [{"t": np.array([0.0, 1.0, 2.0]), "y": [1.0, 2.0, 3.0]}]
+    axis_type = TimeSeriesEditorQt._bokeh_x_axis_type_from_traces(traces)
+    assert axis_type == "linear"


### PR DESCRIPTION
### Motivation
- Bokeh plots were using a linear x-axis even when trace time values were datetimes, causing incorrect axis behavior for datetime series.  
- The plotting pipeline needed a single, reliable way to detect when traces require a Bokeh `datetime` x-axis.

### Description
- Set `x_axis_type` dynamically in the Bokeh grid time plotting branch by calling a new helper to choose `"datetime"` or `"linear"`.  
- Set `x_axis_type` dynamically in the Bokeh line-plot branch (`_plot_lines`) as well so both plot paths behave consistently.  
- Added a helper method `TimeSeriesEditorQt._bokeh_x_axis_type_from_traces(traces)` that inspects trace `t` values and returns `"datetime"` if any trace contains datetime-like values, otherwise `"linear"`.  
- Added two regression tests in `tests/test_merge_selected.py` to assert the helper returns `"datetime"` for `pd.date_range` traces and `"linear"` for numeric traces.

### Testing
- Ran `pytest -q tests/test_timeseries_datetime.py` and it succeeded (`5 passed`).  
- Attempted `pytest -q tests/test_merge_selected.py -k bokeh_axis_type`; the new tests are present but were skipped in this environment due to optional Qt/test gating (no failures observed).  
- No automated test failures introduced by the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f086ae0d98832c9cfdcd93370ea677)