### PR TITLE
Swan tool: enforce plotly-only plotting engine

### DIFF
--- a/anytimes/gui/postprocess_dnora_source.py
+++ b/anytimes/gui/postprocess_dnora_source.py
@@ -901,9 +901,9 @@ def parse_args() -> Inputs:
     )
     parser.add_argument(
         "--plot-engine",
-        choices=["plotly", "default"],
+        choices=["plotly"],
         default="plotly",
-        help="Plot engine for SWAN plots. Use 'default' for matplotlib fallback plots.",
+        help="Plot engine for SWAN plots.",
     )
     parser.add_argument(
         "--split-report-files",
@@ -5722,14 +5722,6 @@ def main() -> None:
         datasets = [(path.parent.name, xr.open_dataset(path)) for path in nc_paths]
         try:
             runs = _prepare_runs_data(datasets)
-            if inputs.plot_engine == "default":
-                _run_matplotlib_fallback(
-                    runs=runs,
-                    point_coord=inputs.point_coord,
-                    output_dir=inputs.directories[0],
-                )
-                return
-
             fig_2d_outputs = build_outputs_figure(
                 datasets=datasets,
                 point_coord=inputs.point_coord,

--- a/anytimes/gui/swan_tool_dialog.py
+++ b/anytimes/gui/swan_tool_dialog.py
@@ -17,7 +17,6 @@ from PySide6.QtWidgets import (
     QAbstractItemView,
     QApplication,
     QCheckBox,
-    QComboBox,
     QDoubleSpinBox,
     QFileDialog,
     QFormLayout,
@@ -189,11 +188,6 @@ class SWANToolDialog(QMainWindow):
         self.spreading_s.setValue(self._DEFAULT_SPREADING_S)
         form.addRow("SPEC_DIR_SPREADING_S", self.spreading_s)
 
-        self.plot_engine = QComboBox()
-        self.plot_engine.addItems(["plotly", "default"])
-        self.plot_engine.setCurrentText(self._DEFAULT_PLOT_ENGINE)
-        self.plot_engine.setToolTip("Select 'default' to use matplotlib fallback plotting.")
-        form.addRow("Plot engine", self.plot_engine)
 
         layout.addWidget(group)
 
@@ -802,7 +796,7 @@ class SWANToolDialog(QMainWindow):
         self._log(f"  DEFAULT_ARROW_RESOLUTION={int(self.arrow_resolution.value())}")
         self._log(f"  SPEC_DIR_THETA_STEP_DEG={self.theta_step.value()}")
         self._log(f"  SPEC_DIR_SPREADING_S={self.spreading_s.value()}")
-        self._log(f"  PLOT_ENGINE={self.plot_engine.currentText()}")
+        self._log(f"  PLOT_ENGINE={self._DEFAULT_PLOT_ENGINE}")
         self._log(f"  Save output requested: {save_output}")
 
         self._set_processing_state(True, mode="Saving output…" if save_output else "Running postprocessing…")
@@ -839,7 +833,7 @@ class SWANToolDialog(QMainWindow):
         cmd += ["--wind-arrow-resolution", str(int(self.arrow_resolution.value()))]
         cmd += ["--spec-dir-theta-step-deg", str(self.theta_step.value())]
         cmd += ["--spec-dir-spreading-s", str(self.spreading_s.value())]
-        cmd += ["--plot-engine", self.plot_engine.currentText()]
+        cmd += ["--plot-engine", self._DEFAULT_PLOT_ENGINE]
         # Ensure report "Map overlay" tab is populated (not "No overlay available").
         cmd += ["--export-hs-format", "geojson", "--export-time-index", "MAX"]
         cmd += ["--split-report-files" if self.split_report_cb.isChecked() else "--single-report-file"]
@@ -866,7 +860,6 @@ class SWANToolDialog(QMainWindow):
         self.arrow_resolution.setValue(self._DEFAULT_ARROW_RESOLUTION)
         self.theta_step.setValue(self._DEFAULT_THETA_STEP)
         self.spreading_s.setValue(self._DEFAULT_SPREADING_S)
-        self.plot_engine.setCurrentText(self._DEFAULT_PLOT_ENGINE)
 
         self._preview_layers = []
         self._spec_points = []


### PR DESCRIPTION
### Motivation
- Remove the UI and runtime option to select a fallback plotting engine so SWAN post-processing always uses Plotly for consistent, modern plotting.
- Prevent accidental use of the matplotlib fallback path and simplify the CLI surface for the SWAN postprocessor.

### Description
- Removed the `Plot engine` `QComboBox` and its UI wiring from `anytimes/gui/swan_tool_dialog.py`, including the `QComboBox` import.
- Updated the SWAN tool dialog to always log and pass the default plot engine via `self._DEFAULT_PLOT_ENGINE` and to always call the postprocessor with `--plot-engine plotly` instead of reading a UI selection.
- Restricted the CLI `--plot-engine` `choices` to only `"plotly"` and simplified the help text in `anytimes/gui/postprocess_dnora_source.py`.
- Removed the runtime branch that executed the matplotlib fallback (`_run_matplotlib_fallback`) when `plot_engine == "default"`, so execution now proceeds through the Plotly plotting path only.

### Testing
- Compiled the modified modules with `python -m py_compile anytimes/gui/swan_tool_dialog.py anytimes/gui/postprocess_dnora_source.py`, and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0895ebbd0832c93abde35f2adb051)