### PR TITLE
Add help dialogs for quick transforms and apply-operation UI; support comma-separated axis markers

### DIFF
--- a/anytimes/gui/editor.py
+++ b/anytimes/gui/editor.py
@@ -371,6 +371,9 @@ class TimeSeriesEditorQt(QMainWindow):
         self.mult_by_2_btn = QPushButton("Multiply by 2")
         self.div_by_2_btn = QPushButton("Divide by 2")
         self.mult_by_neg1_btn = QPushButton("Multiply by -1")
+        self.quick_transform_help_btn = QPushButton("i")
+        self.quick_transform_help_btn.setToolTip("Show help for quick transformation tools.")
+        self.quick_transform_help_btn.setMaximumWidth(28)
         row1.addWidget(self.mult_by_1000_btn)
         row1.addWidget(self.div_by_1000_btn)
         row1.addWidget(self.mult_by_10_btn)
@@ -378,6 +381,7 @@ class TimeSeriesEditorQt(QMainWindow):
         row1.addWidget(self.mult_by_2_btn)
         row1.addWidget(self.div_by_2_btn)
         row1.addWidget(self.mult_by_neg1_btn)
+        row1.addWidget(self.quick_transform_help_btn)
         transform_layout.addLayout(row1)
 
         row2 = QHBoxLayout()
@@ -481,7 +485,8 @@ class TimeSeriesEditorQt(QMainWindow):
         offset_group.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         offset_layout = QVBoxLayout(offset_group)
         offset_examples = QLabel('Examples: add "+1 / 1" substract "-1" divide "/2" multiply "*2"   '
-                                 'To plot 2D scatter input "x" and "y" in the fields. For 3D scatter also input "z".'
+                                 'To plot 2D scatter input "x" and "y" in the fields. For 3D scatter input "z" '
+                                 '(or "z,c" to use z for both axis and color coding).'
                                  ' To include color coding input "c" or "color"'
                                  '  Use Animate button to plot single points over time.')
         offset_examples.setWordWrap(True)
@@ -498,6 +503,11 @@ class TimeSeriesEditorQt(QMainWindow):
 
         self.apply_values_btn = QPushButton("Apply Values")
         self.clear_values_btn = QPushButton("Clear Values")
+        self.apply_operation_help_btn = QPushButton("i")
+        self.apply_operation_help_btn.setToolTip(
+            "Show help for Apply Values and X/Y(/Z) scatter input markers."
+        )
+        self.apply_operation_help_btn.setMaximumWidth(28)
         self.plot_marked_axes_btn = QPushButton("Plot X/Y(/Z)")
         self.animate_marked_axes_btn = QPushButton("Animate X/Y(/Z)")
         self.colormap_label = QLabel("Colormap:")
@@ -540,6 +550,7 @@ class TimeSeriesEditorQt(QMainWindow):
         apply_plot_row = QHBoxLayout()
         apply_plot_row.addWidget(self.apply_values_btn)
         apply_plot_row.addWidget(self.clear_values_btn)
+        apply_plot_row.addWidget(self.apply_operation_help_btn)
         apply_plot_row.addWidget(self.apply_value_user_var_cb)
         apply_plot_row.addWidget(self.plot_marked_axes_btn)
         apply_plot_row.addWidget(self.animate_marked_axes_btn)
@@ -866,8 +877,10 @@ class TimeSeriesEditorQt(QMainWindow):
         self.file_list.currentRowChanged.connect(self.highlight_file_tab)
         self.apply_values_btn.clicked.connect(self.apply_values)
         self.clear_values_btn.clicked.connect(self.clear_all_variable_input_values)
+        self.apply_operation_help_btn.clicked.connect(self.show_apply_operation_help)
         self.plot_marked_axes_btn.clicked.connect(self.plot_marked_axes)
         self.animate_marked_axes_btn.clicked.connect(self.animate_marked_axes)
+        self.quick_transform_help_btn.clicked.connect(self.show_quick_transform_help)
         self.mult_by_1000_btn.clicked.connect(self.multiply_by_1000)
         self.div_by_1000_btn.clicked.connect(self.divide_by_1000)
         self.mult_by_10_btn.clicked.connect(self.multiply_by_10)
@@ -1978,6 +1991,83 @@ class TimeSeriesEditorQt(QMainWindow):
             ),
         )
 
+    def show_apply_operation_help(self):
+        """Show usage information for variable-input operations and scatter plotting."""
+        QMessageBox.information(
+            self,
+            "Apply operation from variable input fields",
+            "\n".join(
+                [
+                    "Apply Values:",
+                    '  • Enter a numeric operation in a variable input field, then click "Apply Values".',
+                    '  • Supported forms: "1" (adds 1), "+1", "-1", "*2", "/2".',
+                    '  • Check "Create user variable instead of overwriting?" to create new variables.',
+                    '  • Click "Clear Values" to empty all variable input fields.',
+                    "",
+                    "Scatter plot markers (Plot X/Y(/Z) and Animate X/Y(/Z)):",
+                    '  • Mark one variable with "x" and one with "y" to create a 2D scatter plot.',
+                    '  • Add "z" for 3D scatter plotting/animation.',
+                    '  • Add "c" or "color" for color coding.',
+                    '  • You can combine markers in one field, e.g. "z,c" to use the same variable',
+                    "    as z-axis and color values.",
+                    "",
+                    "Notes:",
+                    "  • Marker tokens are comma-separated (for example: z,c).",
+                    "  • Resolution percentage controls how many points are used.",
+                    "  • Color Min/Max and clipping affect plotted colors only.",
+                ]
+            ),
+        )
+
+    def show_quick_transform_help(self):
+        """Show usage information for quick transformation controls."""
+        QMessageBox.information(
+            self,
+            "Quick transformations",
+            "\n".join(
+                [
+                    "Quick transformations act on currently selected variables.",
+                    "",
+                    "Basic scaling:",
+                    "  • Multiply/Divide buttons scale the selected series.",
+                    "  • Multiply by -1 flips sign.",
+                    "",
+                    "Angle helpers:",
+                    "  • Radians / Degrees convert angle units.",
+                    "  • Trig + Angle + Calculate applies sin/cos/tan to selected data.",
+                    "",
+                    "Point reduction:",
+                    "  • Reduce Points keeps the requested percentage of points.",
+                    "  • Bias controls how representative points are chosen (Mean/Upper/Lower).",
+                    "",
+                    "Shifting & alignment:",
+                    "  • Shift Mean → 0 and Shift Min to Zero shift each selected series.",
+                    "  • Shift Min -> 0 / Common Shift Min -> 0 use tolerance/min-count controls.",
+                    "  • Shift X Start → 0 creates a new series with x-axis offset from start.",
+                    "",
+                    "Combinations & utilities:",
+                    "  • Sqrt(sum of squares), Mean, Absolute, Rolling Avg, Merge Selected.",
+                    "",
+                    "Tip:",
+                    "  • The frequency-filter section can be applied to transformations/calculations.",
+                ]
+            ),
+        )
+
+    @staticmethod
+    def _parse_axis_roles(raw_text: str) -> set[str]:
+        """Parse marker text from variable input field into axis/color roles."""
+        txt = (raw_text or "").strip().lower()
+        if not txt:
+            return set()
+        roles: set[str] = set()
+        for token in [part.strip() for part in txt.split(",") if part.strip()]:
+            if token == "c":
+                token = "color"
+            if token in {"x", "y", "z", "color"}:
+                roles.add(token)
+        return roles
+
     @staticmethod
     def _region_segments(
         t_vals: np.ndarray,
@@ -2099,10 +2189,7 @@ class TimeSeriesEditorQt(QMainWindow):
         for key, entry in self.var_offsets.items():
             if entry is None:
                 continue
-            role = entry.text().strip().lower()
-            if role == "c":
-                role = "color"
-            if role in role_entries:
+            for role in self._parse_axis_roles(entry.text()):
                 role_entries[role].append(key)
 
         if not role_entries["x"] or not role_entries["y"]:
@@ -2568,10 +2655,7 @@ class TimeSeriesEditorQt(QMainWindow):
         for key, entry in self.var_offsets.items():
             if entry is None:
                 continue
-            role = entry.text().strip().lower()
-            if role == "c":
-                role = "color"
-            if role in role_entries:
+            for role in self._parse_axis_roles(entry.text()):
                 role_entries[role].append(key)
 
         if not role_entries["x"] or not role_entries["y"]:


### PR DESCRIPTION
### Motivation
- Provide in-UI help for the quick transformation and apply-operation/scatter features to reduce user confusion.
- Allow variable input fields to specify multiple roles (x/y/z/color) and support shorthand `c` for color to enable combined markers like `z,c`.
- Clarify the offset/scatter examples text to better describe 3D and color-coding usage.

### Description
- Added help buttons `quick_transform_help_btn` and `apply_operation_help_btn` with tooltips, sizing, and placement in the transformations and apply-operation layouts.
- Implemented `show_quick_transform_help` and `show_apply_operation_help` which display usage information via `QMessageBox.information`.
- Introduced `@staticmethod _parse_axis_roles(raw_text: str) -> set[str]` to parse comma-separated axis/color tokens and normalized `c` to `color`.
- Updated `plot_marked_axes` and `animate_marked_axes` to use `_parse_axis_roles` so a single variable input can declare multiple roles (e.g. `z,c`).
- Updated the `offset_examples` label text to clarify 3D scatter and color-coding input syntax.

### Testing
- Ran the project test suite with `pytest -q` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09684b210832c97a0894b65dfbbe2)