### PR TITLE
Show calculator file IDs in Loaded Files list

### DIFF
--- a/anytimes/gui/editor.py
+++ b/anytimes/gui/editor.py
@@ -4287,11 +4287,19 @@ class TimeSeriesEditorQt(QMainWindow):
 
             self.tsdbs.append(tsdb)
             self.file_paths.append(path)
-            self.file_list.addItem(os.path.basename(path))
+            self._refresh_file_list_display()
             # print(f"Loaded {path}: variables = {list(tsdb.getm().keys())}")
         if errors:
             QMessageBox.warning(self, "Errors occurred", "\n".join([f"{f}: {e}" for f, e in errors]))
         self.refresh_variable_tabs()
+
+
+    def _refresh_file_list_display(self):
+        """Render loaded files with explicit file IDs used by the Calculator."""
+
+        self.file_list.clear()
+        for idx, path in enumerate(self.file_paths, start=1):
+            self.file_list.addItem(f"f{idx}: {os.path.basename(path)}")
 
     def _build_common_lookup(self):
         """Map safe common names to the corresponding variable in each file."""
@@ -4326,7 +4334,7 @@ class TimeSeriesEditorQt(QMainWindow):
             return
         del self.tsdbs[idx]
         del self.file_paths[idx]
-        self.file_list.takeItem(idx)
+        self._refresh_file_list_display()
         self.refresh_variable_tabs()
 
     def clear_all_files(self):


### PR DESCRIPTION
### Motivation
- Make the numbering used by the Calculator visible in the UI by prefixing each loaded file with its calculator file ID (e.g. `f1: filename`), ensuring users can map list entries to calculator references.
- Keep existing Calculator parsing and backend logic unchanged while aligning the UI labeling with the Calculator notation.

### Description
- Added a `_refresh_file_list_display()` helper that rebuilds `self.file_list` from `self.file_paths` and formats entries as `f{N}: {basename}`.
- Updated the file loading flow to call `_refresh_file_list_display()` instead of adding a raw basename via `addItem`, and updated file removal to rebuild the list after deleting entries.
- The visible file list now shows explicit IDs without changing variable naming, calculator parsing, or other functionality.

### Testing
- Ran `python -m pytest -q tests/test_file_loader.py tests/test_merge_selected.py tests/test_filename_parser.py` which completed with `30 passed, 1 skipped`.
- No tests failed and the existing test-suite covered file loading/merge/filename parsing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1bc84b510832cb52467321f950bb9)