### PR TITLE
Document SWANpost support for non-stationary netCDF and show note in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The application integrates with the bundled **anyqats** package and supports a b
 ### Convenience utilities
 - Switch between light and dark themes, embed plots, open external viewers and manage offsets/scaling presets via save/load dialogs.
 - Track file loading progress with an integrated progress bar and optional preloading callbacks.
-- Run **SWANpost** from the Tools panel: open one or many SWAN output folders at once, generate a contour line depth map (highlighting the 0-line and standard levels such as 10/20/50/200/400, with fallback to `.BOT` depth when needed), pick POIs by clicking the map (or type POIs manually), and run full DNORA/SWAN postprocessing for each folder/POI combination.
+- Run **SWANpost** from the Tools panel: the current version supports non-stationary netCDF files, lets you open one or many SWAN output folders at once, generates a contour line depth map (highlighting the 0-line and standard levels such as 10/20/50/200/400, with fallback to `.BOT` depth when needed), lets you pick POIs by clicking the map (or type POIs manually), and runs full DNORA/SWAN postprocessing for each folder/POI combination.
 
 
 <p align="center">

--- a/anytimes/gui/swanpost_dialog.py
+++ b/anytimes/gui/swanpost_dialog.py
@@ -37,6 +37,10 @@ class SWANpostDialog(QDialog):
         self._depth_source: Path | None = None
 
         root = QVBoxLayout(self)
+
+        support_note = QLabel("Current version supports non-stationary netCDF files.", self)
+        root.addWidget(support_note)
+
         controls = QGridLayout()
 
         controls.addWidget(QLabel("Folders to process:"), 0, 0)


### PR DESCRIPTION
### Motivation
- Inform users that the SWANpost tool now supports non-stationary netCDF files by surfacing the capability in the README and the SWANpost dialog UI.

### Description
- Updated `README.md` to expand the SWANpost description to mention non-stationary netCDF support and modified `anytimes/gui/swanpost_dialog.py` to add a `QLabel` displaying "Current version supports non-stationary netCDF files." at the top of the dialog.

### Testing
- No automated tests were added or modified; the existing test suite was executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1be0f67b4832c80729dddd8c93015)