### PR TITLE
Calculator: write outputs only to referenced files (stop cross-file duplication)

### DIFF
--- a/anytimes/gui/editor.py
+++ b/anytimes/gui/editor.py
@@ -1494,7 +1494,7 @@ class TimeSeriesEditorQt(QMainWindow):
         for file_idx, tsdb in enumerate(self.tsdbs):
             f_no = file_idx + 1
             y = evaluated_results[file_idx]
-            must_write_here = (create_common_output and f_no == min(file_tags_used)) or (not create_common_output and f_no in file_tags_used)
+            must_write_here = f_no in file_tags_used
             if not must_write_here:
                 continue
 
@@ -1509,11 +1509,6 @@ class TimeSeriesEditorQt(QMainWindow):
             ts_new = qats.TimeSeries(out_name, time_window, y, dtg_ref=dtg_ref)
 
             tsdb.add(ts_new)
-
-            if create_common_output:
-                for other_db in self.tsdbs:
-                    if out_name not in other_db.getm():
-                        other_db.add(ts_new.copy())
 
             self.user_variables = getattr(self, "user_variables", set())
             self.user_variables.add(out_name)


### PR DESCRIPTION
### Motivation
- Calculator expressions were creating a single output and copying it to all loaded files when multiple file tags were involved, causing unrelated files to receive identical user variables.
- The intent is that calculator operations should only affect selected/referenced file(s) and that created user variables should contain values only for those files.
- This change enforces that behavior for both explicitly named outputs (`name = ...`) and auto-generated output names.

### Description
- Changed the write-condition so outputs are created only for files in `file_tags_used` by setting `must_write_here = f_no in file_tags_used` in `anytimes/gui/editor.py`.
- Removed logic that replicated a single "common" output to every loaded file, preventing propagation of identical variables to non-referenced files.
- Preserved the existing output naming and time-window/dtg handling so `create_common_output` still controls naming but no longer triggers cross-file copies.

### Testing
- Ran `pytest -q tests/test_filename_parser.py` and it passed (`5 passed`).
- Ran `pytest -q tests/test_merge_selected.py` in this environment and it reported a skip-only result (`1 skipped`); no failures observed.
- No other automated tests were run as part of this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e97d4f40832c9b0b2c389335ac86)