### PR TITLE
Add OpenFOAM reporting .dat support in ASCII loader

### DIFF
--- a/anyqats/io/other.py
+++ b/anyqats/io/other.py
@@ -6,6 +6,30 @@ import fnmatch
 import numpy as np
 
 
+def _extract_dat_header_tokens(path):
+    """Return header tokens from .dat-like ASCII files."""
+    header_tokens = None
+    with open(path) as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            candidate = stripped
+            if stripped.startswith("#"):
+                candidate = stripped.lstrip("#").strip()
+
+            if not candidate:
+                continue
+
+            tokens = candidate.split()
+            if fnmatch.filter(tokens, "[Tt]ime*"):
+                header_tokens = tokens
+                break
+
+    return header_tokens
+
+
 def read_dat_names(path):
     """
     Read time series names from an ASCII file with data arranged column-wise. The names are in the first non-commented
@@ -26,14 +50,8 @@ def read_dat_names(path):
     The names are extracted from the header row (the first non-commented row). The comment character is '#'. Time is
     assumed to be in the first column.
     """
-    names = None
-    with open(path) as f:
-        for line in f:
-            if not line.startswith("#"):
-                # names in first row that is not a comment
-                names = line.split()
-                break
-    
+    names = _extract_dat_header_tokens(path)
+
     if names is not None:
         # identify time key, check that there is only one
         timekeys = fnmatch.filter(names, '[Tt]ime*')
@@ -72,15 +90,7 @@ def read_dat_data(path, ind=None):
     ``data[1,:]``.
 
     """
-    with open(path, 'r') as f:
-        # skip commented lines at beginning of file
-        for line in f:
-            # break at first uncommented line (which is the header row and should not be read here)
-            if not line.startswith("#"):
-                break
-        
-        # load data, skipping commented lines and the header row with keys (first uncommented line)
-        data = np.loadtxt(f, skiprows=0, usecols=ind, unpack=True)
+    data = np.loadtxt(path, comments="#", usecols=ind, unpack=True)
 
     return data
 

--- a/tests/test_openfoam_dat_loader.py
+++ b/tests/test_openfoam_dat_loader.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from anyqats.io.other import read_dat_data, read_dat_names
+
+
+def test_read_openfoam_dat_names_and_data(tmp_path):
+    path = tmp_path / "forces.dat"
+    path.write_text(
+        "# Force\n"
+        "# CofR : (0 0 0)\n"
+        "#\n"
+        "# Time total_x total_y total_z pressure_x pressure_y pressure_z viscous_x viscous_y viscous_z\n"
+        "0.1 1 2 3 4 5 6 7 8 9\n"
+        "0.2 10 20 30 40 50 60 70 80 90\n",
+        encoding="utf-8",
+    )
+
+    names = read_dat_names(str(path))
+    assert names == [
+        "total_x",
+        "total_y",
+        "total_z",
+        "pressure_x",
+        "pressure_y",
+        "pressure_z",
+        "viscous_x",
+        "viscous_y",
+        "viscous_z",
+    ]
+
+    data = read_dat_data(str(path), ind=[0, 1, 9])
+    assert data.shape == (3, 2)
+    assert np.allclose(data[0], [0.1, 0.2])
+    assert np.allclose(data[1], [1.0, 10.0])
+    assert np.allclose(data[2], [9.0, 90.0])


### PR DESCRIPTION
### Motivation
- Some OpenFOAM reporting `.dat` files include leading metadata comment lines and a header row that itself is commented (e.g. `# Time ...`), which the existing parser did not correctly detect. 
- The loader needs robust header detection that recognizes a `Time` column whether the header line is commented or not. 
- Numeric loading should consistently ignore comment lines to avoid fragile manual-skipping logic.

### Description
- Added a helper `def _extract_dat_header_tokens(path)` that scans the file for the first tokenized line containing a `Time` token and returns the header tokens, supporting both commented and uncommented header rows. 
- Updated `read_dat_names` to use `_extract_dat_header_tokens(path)` and keep the existing validation that exactly one `Time` column is present and that the returned list skips the time column. 
- Simplified `read_dat_data` to `numpy.loadtxt(path, comments="#", usecols=ind, unpack=True)` so commented lines are ignored reliably, and added `tests/test_openfoam_dat_loader.py` which includes an OpenFOAM-style sample file and checks both names and indexed numeric loading.

### Testing
- Ran `pytest -q tests/test_openfoam_dat_loader.py` which passed (`1 passed`) with unrelated warnings. 
- The new test verifies that `read_dat_names` extracts the expected series names from a commented OpenFOAM-style header and that `read_dat_data` returns indexed columns correctly. 
- No additional automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f8f9e534832ca44162c8b00ac965)